### PR TITLE
feat(store): add truncate instead of the round as parameter for the decimalToPrecision function

### DIFF
--- a/examples/js/coinbase-fetch-ETHUSDT-trades.js
+++ b/examples/js/coinbase-fetch-ETHUSDT-trades.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const ccxt = require('../../ccxt.js')
+
+console.log('CCXT Version:', ccxt.version)
+
+async function main() {
+    const exchange = new ccxt.coinbase({
+        apiKey: 'YOU API KEY',
+        secret: 'YOUR SECRET KEY',
+    })
+    const markets = await exchange.loadMarkets()
+    // coinbase.verbose = true // uncomment for debugging purposes if necessary
+    const trades = await exchange.fetchMyTrades('ETH/USDT')
+    console.log(trades)
+}
+
+main()

--- a/examples/js/huobi-withdraw.js
+++ b/examples/js/huobi-withdraw.js
@@ -1,0 +1,29 @@
+const ccxt = require ('../../ccxt');
+
+const exchange = new ccxt.gateio ({
+    'apiKey': 'YOUR_API_KEY',
+    'secret': 'YOUR_SECRET_KEY',
+    'enableRateLimit': true,
+})
+
+// IMPORTANT: To test without losing assets, add an asset you don't have on the account
+const tokenWithdrawData = {
+    tokenSymbol: "ADA",
+    amount: "0.51829369992939",
+    chain: "ADA",
+    recipientAddress: "YOUR_WALLET_ADDRESS",
+};
+
+const params = {
+    network: 'ADA', // 'ERC20', 'TRC20', 'BSC', default is ERC20
+    code: 'ADA',
+};
+
+;(async () => {
+    try {
+        const result = await exchange.withdraw(tokenWithdrawData.tokenSymbol, tokenWithdrawData.amount, tokenWithdrawData.recipientAddress, undefined, params);
+        console.log(result);
+    } catch (e) {
+        console.log (e.constructor.name, e.message)
+    }
+}) ()

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2035,7 +2035,9 @@ module.exports = class Exchange {
     async fetch2(path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined, config = {}, context = {}) {
         if (this.enableRateLimit) {
             const cost = this.calculateRateLimiterCost(api, method, path, params, config, context);
-            await this.throttle(cost, path);
+            await this.throttle(cost, path, params?.customThrottleConfig);
+            delete params?.customExpireInterval;
+            delete params?.customPriority;
         }
         this.lastRestRequestTimestamp = this.milliseconds();
         const request = this.sign(path, api, method, params, headers, body);

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2667,7 +2667,7 @@ module.exports = class Exchange {
         if (precision === undefined) {
             return fee;
         } else {
-            return this.decimalToPrecision(fee, ROUND, precision, this.precisionMode, this.paddingMode);
+            return this.decimalToPrecision(fee, TRUNCATE, precision, this.precisionMode, this.paddingMode);
         }
     }
 

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -3,13 +3,13 @@
 // ----------------------------------------------------------------------------
 /* eslint-disable */
 
-const functions = require ('./functions');
+const functions = require('./functions');
 
 const {
     isNode
     , clone
     , unCamelCase
-    , throttle
+    , customThrottle
     , timeout
     , TimedOut
     , defaultFetch
@@ -227,8 +227,8 @@ module.exports = class Exchange {
         } // return
     } // describe ()
 
-    constructor (userConfig = {}) {
-        Object.assign (this, functions)
+    constructor(userConfig = {}) {
+        Object.assign(this, functions)
         //
         //     if (isNode) {
         //         this.nodeVersion = process.version.match (/\d+\.\d+\.\d+/)[0]
@@ -267,30 +267,30 @@ module.exports = class Exchange {
         this.validateServerSsl = true
         this.validateClientSsl = false
         // default property values
-        this.timeout       = 10000 // milliseconds
-        this.verbose       = false
-        this.debug         = false
-        this.userAgent     = undefined
-        this.twofa         = undefined // two-factor authentication (2FA)
+        this.timeout = 10000 // milliseconds
+        this.verbose = false
+        this.debug = false
+        this.userAgent = undefined
+        this.twofa = undefined // two-factor authentication (2FA)
         // default credentials
-        this.apiKey        = undefined
-        this.secret        = undefined
-        this.uid           = undefined
-        this.login         = undefined
-        this.password      = undefined
-        this.privateKey    = undefined // a "0x"-prefixed hexstring private key for a wallet
+        this.apiKey = undefined
+        this.secret = undefined
+        this.uid = undefined
+        this.login = undefined
+        this.password = undefined
+        this.privateKey = undefined // a "0x"-prefixed hexstring private key for a wallet
         this.walletAddress = undefined // a wallet address "0x"-prefixed hexstring
-        this.token         = undefined // reserved for HTTP auth in some cases
+        this.token = undefined // reserved for HTTP auth in some cases
         // placeholders for cached data
-        this.balance      = {}
-        this.orderbooks   = {}
-        this.tickers      = {}
-        this.orders       = undefined
-        this.trades       = {}
+        this.balance = {}
+        this.orderbooks = {}
+        this.tickers = {}
+        this.orders = undefined
+        this.trades = {}
         this.transactions = {}
-        this.ohlcvs       = {}
-        this.myTrades     = undefined
-        this.positions    = {}
+        this.ohlcvs = {}
+        this.myTrades = undefined
+        this.positions = {}
         // web3 and cryptography flags
         this.requiresWeb3 = false
         this.requiresEddsa = false
@@ -300,18 +300,18 @@ module.exports = class Exchange {
         this.enableLastJsonResponse = true
         this.enableLastHttpResponse = true
         this.enableLastResponseHeaders = true
-        this.last_http_response    = undefined
-        this.last_json_response    = undefined
+        this.last_http_response = undefined
+        this.last_json_response = undefined
         this.last_response_headers = undefined
         // camelCase and snake_notation support
         const unCamelCaseProperties = (obj = this) => {
             if (obj !== null) {
-                const ownPropertyNames = Object.getOwnPropertyNames (obj)
+                const ownPropertyNames = Object.getOwnPropertyNames(obj)
                 for (let i = 0; i < ownPropertyNames.length; i++) {
                     const k = ownPropertyNames[i]
-                    this[unCamelCase (k)] = this[k]
+                    this[unCamelCase(k)] = this[k]
                 }
-                unCamelCaseProperties (Object.getPrototypeOf (obj))
+                unCamelCaseProperties(Object.getPrototypeOf(obj))
             }
         }
         unCamelCaseProperties ()
@@ -414,7 +414,7 @@ module.exports = class Exchange {
             maxCapacity: 1000,
             refillRate: (this.rateLimit > 0) ? 1 / this.rateLimit : Number.MAX_VALUE,
         }, this.tokenBucket);
-        this.throttle = throttle (this.tokenBucket);
+        this.throttle = customThrottle(this.tokenBucket);
         this.executeRestRequest = (url, method = 'GET', headers = undefined, body = undefined) => {
             // fetchImplementation cannot be called on this. in browsers:
             // TypeError Failed to execute 'fetch' on 'Window': Illegal invocation
@@ -422,137 +422,137 @@ module.exports = class Exchange {
             const params = { method, headers, body, timeout: this.timeout };
             if (this.agent) {
                 params['agent'] = this.agent;
-            } else if (this.httpAgent && url.indexOf ('http://') === 0) {
+            } else if (this.httpAgent && url.indexOf('http://') === 0) {
                 params['agent'] = this.httpAgent;
-            } else if (this.httpsAgent && url.indexOf ('https://') === 0) {
+            } else if (this.httpsAgent && url.indexOf('https://') === 0) {
                 params['agent'] = this.httpsAgent;
             }
             const promise =
-                fetchImplementation (url, this.extend (params, this.fetchOptions))
-                    .catch ((e) => {
+                fetchImplementation(url, this.extend(params, this.fetchOptions))
+                    .catch((e) => {
                         if (isNode) {
-                            throw new ExchangeNotAvailable ([ this.id, method, url, e.type, e.message ].join (' '));
+                            throw new ExchangeNotAvailable([this.id, method, url, e.type, e.message].join(' '));
                         }
                         throw e; // rethrow all unknown errors
                     })
-                    .then ((response) => this.handleRestResponse (response, url, method, headers, body));
-            return timeout (this.timeout, promise).catch ((e) => {
+                    .then((response) => this.handleRestResponse(response, url, method, headers, body));
+            return timeout(this.timeout, promise).catch((e) => {
                 if (e instanceof TimedOut) {
-                    throw new RequestTimeout (this.id + ' ' + method + ' ' + url + ' request timed out (' + this.timeout + ' ms)');
+                    throw new RequestTimeout(this.id + ' ' + method + ' ' + url + ' request timed out (' + this.timeout + ' ms)');
                 }
                 throw e;
             })
         };
     }
 
-    setSandboxMode (enabled) {
+    setSandboxMode(enabled) {
         if (!!enabled) { // eslint-disable-line no-extra-boolean-cast
             if ('test' in this.urls) {
                 if (typeof this.urls['api'] === 'string') {
                     this.urls['apiBackup'] = this.urls['api']
                     this.urls['api'] = this.urls['test']
                 } else {
-                    this.urls['apiBackup'] = clone (this.urls['api'])
-                    this.urls['api'] = clone (this.urls['test'])
+                    this.urls['apiBackup'] = clone(this.urls['api'])
+                    this.urls['api'] = clone(this.urls['test'])
                 }
             } else {
-                throw new NotSupported (this.id + ' does not have a sandbox URL')
+                throw new NotSupported(this.id + ' does not have a sandbox URL')
             }
         } else if ('apiBackup' in this.urls) {
             if (typeof this.urls['api'] === 'string') {
                 this.urls['api'] = this.urls['apiBackup']
             } else {
-                this.urls['api'] = clone (this.urls['apiBackup'])
+                this.urls['api'] = clone(this.urls['apiBackup'])
             }
         }
     }
 
-    defineRestApiEndpoint (methodName, uppercaseMethod, lowercaseMethod, camelcaseMethod, path, paths, config = {}) {
-        const splitPath = path.split (/[^a-zA-Z0-9]/)
-        const camelcaseSuffix  = splitPath.map (this.capitalize).join ('')
-        const underscoreSuffix = splitPath.map ((x) => x.trim ().toLowerCase ()).filter ((x) => x.length > 0).join ('_')
-        const camelcasePrefix = [ paths[0] ].concat (paths.slice (1).map (this.capitalize)).join ('')
-        const underscorePrefix = [ paths[0] ].concat (paths.slice (1).map ((x) => x.trim ()).filter ((x) => x.length > 0)).join ('_')
-        const camelcase  = camelcasePrefix + camelcaseMethod + this.capitalize (camelcaseSuffix)
+    defineRestApiEndpoint(methodName, uppercaseMethod, lowercaseMethod, camelcaseMethod, path, paths, config = {}) {
+        const splitPath = path.split(/[^a-zA-Z0-9]/)
+        const camelcaseSuffix = splitPath.map(this.capitalize).join('')
+        const underscoreSuffix = splitPath.map((x) => x.trim().toLowerCase()).filter((x) => x.length > 0).join('_')
+        const camelcasePrefix = [paths[0]].concat(paths.slice(1).map(this.capitalize)).join('')
+        const underscorePrefix = [paths[0]].concat(paths.slice(1).map((x) => x.trim()).filter((x) => x.length > 0)).join('_')
+        const camelcase = camelcasePrefix + camelcaseMethod + this.capitalize(camelcaseSuffix)
         const underscore = underscorePrefix + '_' + lowercaseMethod + '_' + underscoreSuffix
         const typeArgument = (paths.length > 1) ? paths : paths[0]
         // handle call costs here
-        const partial = async (params = {}, context = {}) => this[methodName] (path, typeArgument, uppercaseMethod, params, undefined, undefined, config, context)
+        const partial = async (params = {}, context = {}) => this[methodName](path, typeArgument, uppercaseMethod, params, undefined, undefined, config, context)
         // const partial = async (params) => this[methodName] (path, typeArgument, uppercaseMethod, params || {})
-        this[camelcase]  = partial
+        this[camelcase] = partial
         this[underscore] = partial
     }
 
-    defineRestApi (api, methodName, paths = []) {
-        const keys = Object.keys (api)
+    defineRestApi(api, methodName, paths = []) {
+        const keys = Object.keys(api)
         for (let i = 0; i < keys.length; i++) {
             const key = keys[i]
             const value = api[key]
-            const uppercaseMethod = key.toUpperCase ()
-            const lowercaseMethod = key.toLowerCase ()
-            const camelcaseMethod = this.capitalize (lowercaseMethod)
-            if (Array.isArray (value)) {
+            const uppercaseMethod = key.toUpperCase()
+            const lowercaseMethod = key.toLowerCase()
+            const camelcaseMethod = this.capitalize(lowercaseMethod)
+            if (Array.isArray(value)) {
                 for (let k = 0; k < value.length; k++) {
-                    const path = value[k].trim ()
-                    this.defineRestApiEndpoint (methodName, uppercaseMethod, lowercaseMethod, camelcaseMethod, path, paths)
+                    const path = value[k].trim()
+                    this.defineRestApiEndpoint(methodName, uppercaseMethod, lowercaseMethod, camelcaseMethod, path, paths)
                 }
-            // the options HTTP method conflicts with the 'options' API url path
-            // } else if (key.match (/^(?:get|post|put|delete|options|head|patch)$/i)) {
-            } else if (key.match (/^(?:get|post|put|delete|head|patch)$/i)) {
-                const endpoints = Object.keys (value);
+                // the options HTTP method conflicts with the 'options' API url path
+                // } else if (key.match (/^(?:get|post|put|delete|options|head|patch)$/i)) {
+            } else if (key.match(/^(?:get|post|put|delete|head|patch)$/i)) {
+                const endpoints = Object.keys(value);
                 for (let j = 0; j < endpoints.length; j++) {
                     const endpoint = endpoints[j]
-                    const path = endpoint.trim ()
+                    const path = endpoint.trim()
                     const config = value[endpoint]
                     if (typeof config === 'object') {
-                        this.defineRestApiEndpoint (methodName, uppercaseMethod, lowercaseMethod, camelcaseMethod, path, paths, config)
+                        this.defineRestApiEndpoint(methodName, uppercaseMethod, lowercaseMethod, camelcaseMethod, path, paths, config)
                     } else if (typeof config === 'number') {
-                        this.defineRestApiEndpoint (methodName, uppercaseMethod, lowercaseMethod, camelcaseMethod, path, paths, { cost: config })
+                        this.defineRestApiEndpoint(methodName, uppercaseMethod, lowercaseMethod, camelcaseMethod, path, paths, { cost: config })
                     } else {
-                        throw new NotSupported (this.id + ' defineRestApi() API format is not supported, API leafs must strings, objects or numbers');
+                        throw new NotSupported(this.id + ' defineRestApi() API format is not supported, API leafs must strings, objects or numbers');
                     }
                 }
             } else {
-                this.defineRestApi (value, methodName, paths.concat ([ key ]))
+                this.defineRestApi(value, methodName, paths.concat([key]))
             }
         }
     }
 
-    log (... args) {
-        console.log (... args)
+    log(...args) {
+        console.log(...args)
     }
 
-    fetch (url, method = 'GET', headers = undefined, body = undefined) {
+    fetch(url, method = 'GET', headers = undefined, body = undefined) {
         if (isNode && this.userAgent) {
             if (typeof this.userAgent === 'string') {
-                headers = this.extend ({ 'User-Agent': this.userAgent }, headers)
+                headers = this.extend({ 'User-Agent': this.userAgent }, headers)
             } else if ((typeof this.userAgent === 'object') && ('User-Agent' in this.userAgent)) {
-                headers = this.extend (this.userAgent, headers)
+                headers = this.extend(this.userAgent, headers)
             }
         }
         if (typeof this.proxy === 'function') {
-            url = this.proxy (url)
+            url = this.proxy(url)
             if (isNode) {
-                headers = this.extend ({ 'Origin': this.origin }, headers)
+                headers = this.extend({ 'Origin': this.origin }, headers)
             }
         } else if (typeof this.proxy === 'string') {
             if (this.proxy.length && isNode) {
-                headers = this.extend ({ 'Origin': this.origin }, headers)
+                headers = this.extend({ 'Origin': this.origin }, headers)
             }
             url = this.proxy + url
         }
-        headers = this.extend (this.headers, headers)
-        headers = this.setHeaders (headers)
+        headers = this.extend(this.headers, headers)
+        headers = this.setHeaders(headers)
         if (this.verbose) {
-            this.log ("fetch Request:\n", this.id, method, url, "\nRequestHeaders:\n", headers, "\nRequestBody:\n", body, "\n")
+            this.log("fetch Request:\n", this.id, method, url, "\nRequestHeaders:\n", headers, "\nRequestBody:\n", body, "\n")
         }
-        return this.executeRestRequest (url, method, headers, body)
+        return this.executeRestRequest(url, method, headers, body)
     }
 
-    parseJson (jsonString) {
+    parseJson(jsonString) {
         try {
-            if (this.isJsonEncodedObject (jsonString)) {
-                return JSON.parse (this.onJsonResponse (jsonString))
+            if (this.isJsonEncodedObject(jsonString)) {
+                return JSON.parse(this.onJsonResponse(jsonString))
             }
         } catch (e) {
             // SyntaxError
@@ -560,19 +560,19 @@ module.exports = class Exchange {
         }
     }
 
-    getResponseHeaders (response) {
+    getResponseHeaders(response) {
         const result = {}
-        response.headers.forEach ((value, key) => {
-            key = key.split ('-').map ((word) => this.capitalize (word)).join ('-')
+        response.headers.forEach((value, key) => {
+            key = key.split('-').map((word) => this.capitalize(word)).join('-')
             result[key] = value
         })
         return result
     }
 
-    handleRestResponse (response, url, method = 'GET', requestHeaders = undefined, requestBody = undefined) {
-        const responseHeaders = this.getResponseHeaders (response)
+    handleRestResponse(response, url, method = 'GET', requestHeaders = undefined, requestBody = undefined) {
+        const responseHeaders = this.getResponseHeaders(response)
         if (this.handleContentTypeApplicationZip && (responseHeaders['Content-Type'] === 'application/zip')) {
-            const responseBuffer = response.buffer ();
+            const responseBuffer = response.buffer();
             if (this.enableLastResponseHeaders) {
                 this.last_response_headers = responseHeaders
             }
@@ -580,14 +580,14 @@ module.exports = class Exchange {
                 this.last_http_response = responseBuffer
             }
             if (this.verbose) {
-                this.log ("handleRestResponse:\n", this.id, method, url, response.status, response.statusText, "\nResponseHeaders:\n", responseHeaders, "ZIP redacted", "\n")
+                this.log("handleRestResponse:\n", this.id, method, url, response.status, response.statusText, "\nResponseHeaders:\n", responseHeaders, "ZIP redacted", "\n")
             }
             // no error handler needed, because it would not be a zip response in case of an error
             return responseBuffer;
         }
-        return response.text ().then ((responseBody) => {
-            const bodyText = this.onRestResponse (response.status, response.statusText, url, method, responseHeaders, responseBody, requestHeaders, requestBody);
-            const json = this.parseJson (bodyText)
+        return response.text().then((responseBody) => {
+            const bodyText = this.onRestResponse(response.status, response.statusText, url, method, responseHeaders, responseBody, requestHeaders, requestBody);
+            const json = this.parseJson(bodyText)
             if (this.enableLastResponseHeaders) {
                 this.last_response_headers = responseHeaders
             }
@@ -598,45 +598,45 @@ module.exports = class Exchange {
                 this.last_json_response = json
             }
             if (this.verbose) {
-                this.log ("handleRestResponse:\n", this.id, method, url, response.status, response.statusText, "\nResponseHeaders:\n", responseHeaders, "\nResponseBody:\n", responseBody, "\n")
+                this.log("handleRestResponse:\n", this.id, method, url, response.status, response.statusText, "\nResponseHeaders:\n", responseHeaders, "\nResponseBody:\n", responseBody, "\n")
             }
-            const skipFurtherErrorHandling = this.handleErrors (response.status, response.statusText, url, method, responseHeaders, responseBody, json, requestHeaders, requestBody)
+            const skipFurtherErrorHandling = this.handleErrors(response.status, response.statusText, url, method, responseHeaders, responseBody, json, requestHeaders, requestBody)
             if (!skipFurtherErrorHandling) {
-                this.handleHttpStatusCode (response.status, response.statusText, url, method, responseBody)
+                this.handleHttpStatusCode(response.status, response.statusText, url, method, responseBody)
             }
             return json || responseBody
         })
     }
 
-    onRestResponse (statusCode, statusText, url, method, responseHeaders, responseBody, requestHeaders, requestBody) {
-        return responseBody.trim ()
+    onRestResponse(statusCode, statusText, url, method, responseHeaders, responseBody, requestHeaders, requestBody) {
+        return responseBody.trim()
     }
 
-    onJsonResponse (responseBody) {
-        return this.quoteJsonNumbers ? responseBody.replace (/":([+.0-9eE-]+)([,}])/g, '":"$1"$2') : responseBody;
+    onJsonResponse(responseBody) {
+        return this.quoteJsonNumbers ? responseBody.replace(/":([+.0-9eE-]+)([,}])/g, '":"$1"$2') : responseBody;
     }
 
-    async loadMarketsHelper (reload = false, params = {}) {
+    async loadMarketsHelper(reload = false, params = {}) {
         if (!reload && this.markets) {
             if (!this.markets_by_id) {
-                return this.setMarkets (this.markets)
+                return this.setMarkets(this.markets)
             }
             return this.markets
         }
         let currencies = undefined
         // only call if exchange API provides endpoint (true), thus avoid emulated versions ('emulated')
         if (this.has.fetchCurrencies === true) {
-            currencies = await this.fetchCurrencies ()
+            currencies = await this.fetchCurrencies()
         }
-        const markets = await this.fetchMarkets (params)
-        return this.setMarkets (markets, currencies)
+        const markets = await this.fetchMarkets(params)
+        return this.setMarkets(markets, currencies)
     }
 
-    loadMarkets (reload = false, params = {}) {
+    loadMarkets(reload = false, params = {}) {
         // this method is async, it returns a promise
         if ((reload && !this.reloadingMarkets) || !this.marketsLoading) {
             this.reloadingMarkets = true
-            this.marketsLoading = this.loadMarketsHelper (reload, params).then ((resolved) => {
+            this.marketsLoading = this.loadMarketsHelper(reload, params).then((resolved) => {
                 this.reloadingMarkets = false
                 return resolved
             }, (error) => {
@@ -647,69 +647,69 @@ module.exports = class Exchange {
         return this.marketsLoading
     }
 
-    fetchCurrencies (params = {}) {
+    fetchCurrencies(params = {}) {
         // markets are returned as a list
         // currencies are returned as a dict
         // this is for historical reasons
         // and may be changed for consistency later
-        return new Promise ((resolve, reject) => resolve (this.currencies));
+        return new Promise((resolve, reject) => resolve(this.currencies));
     }
 
-    fetchMarkets (params = {}) {
+    fetchMarkets(params = {}) {
         // markets are returned as a list
         // currencies are returned as a dict
         // this is for historical reasons
         // and may be changed for consistency later
-        return new Promise ((resolve, reject) => resolve (Object.values (this.markets)))
+        return new Promise((resolve, reject) => resolve(Object.values(this.markets)))
     }
 
-    filterBySinceLimit (array, since = undefined, limit = undefined, key = 'timestamp', tail = false) {
+    filterBySinceLimit(array, since = undefined, limit = undefined, key = 'timestamp', tail = false) {
         const sinceIsDefined = (since !== undefined && since !== null)
         if (sinceIsDefined) {
-            array = array.filter ((entry) => entry[key] >= since)
+            array = array.filter((entry) => entry[key] >= since)
         }
         if (limit !== undefined && limit !== null) {
-            array = tail ? array.slice (-limit) : array.slice (0, limit)
+            array = tail ? array.slice(-limit) : array.slice(0, limit)
         }
         return array
     }
 
-    filterByValueSinceLimit (array, field, value = undefined, since = undefined, limit = undefined, key = 'timestamp', tail = false) {
+    filterByValueSinceLimit(array, field, value = undefined, since = undefined, limit = undefined, key = 'timestamp', tail = false) {
         const valueIsDefined = value !== undefined && value !== null
         const sinceIsDefined = since !== undefined && since !== null
         // single-pass filter for both symbol and since
         if (valueIsDefined || sinceIsDefined) {
-            array = array.filter ((entry) =>
-                ((valueIsDefined ? (entry[field] === value) : true) &&
-                 (sinceIsDefined ? (entry[key] >= since) : true)))
+            array = array.filter((entry) =>
+            ((valueIsDefined ? (entry[field] === value) : true) &&
+                (sinceIsDefined ? (entry[key] >= since) : true)))
         }
         if (limit !== undefined && limit !== null) {
-            array = tail ? array.slice (-limit) : array.slice (0, limit)
+            array = tail ? array.slice(-limit) : array.slice(0, limit)
         }
         return array
     }
 
-    checkRequiredDependencies () {
+    checkRequiredDependencies() {
         return
     }
 
-    remove0xPrefix (hexData) {
-        if (hexData.slice (0, 2) === '0x') {
-            return hexData.slice (2)
+    remove0xPrefix(hexData) {
+        if (hexData.slice(0, 2) === '0x') {
+            return hexData.slice(2)
         } else {
             return hexData
         }
     }
 
-    hashMessage (message) {
+    hashMessage(message) {
         // takes a hex encoded message
-        const binaryMessage = this.base16ToBinary (this.remove0xPrefix (message))
-        const prefix = this.stringToBinary ('\x19Ethereum Signed Message:\n' + binaryMessage.sigBytes)
-        return '0x' + this.hash (this.binaryConcat (prefix, binaryMessage), 'keccak', 'hex')
+        const binaryMessage = this.base16ToBinary(this.remove0xPrefix(message))
+        const prefix = this.stringToBinary('\x19Ethereum Signed Message:\n' + binaryMessage.sigBytes)
+        return '0x' + this.hash(this.binaryConcat(prefix, binaryMessage), 'keccak', 'hex')
     }
 
-    signHash (hash, privateKey) {
-        const signature = this.ecdsa (hash.slice (-64), privateKey.slice (-64), 'secp256k1', undefined)
+    signHash(hash, privateKey) {
+        const signature = this.ecdsa(hash.slice(-64), privateKey.slice(-64), 'secp256k1', undefined)
         return {
             'r': '0x' + signature['r'],
             's': '0x' + signature['s'],
@@ -717,45 +717,45 @@ module.exports = class Exchange {
         }
     }
 
-    signMessage (message, privateKey) {
-        return this.signHash (this.hashMessage (message), privateKey.slice (-64))
+    signMessage(message, privateKey) {
+        return this.signHash(this.hashMessage(message), privateKey.slice(-64))
     }
 
-    signMessageString (message, privateKey) {
+    signMessageString(message, privateKey) {
         // still takes the input as a hex string
         // same as above but returns a string instead of an object
-        const signature = this.signMessage (message, privateKey)
-        return signature['r'] + this.remove0xPrefix (signature['s']) + this.binaryToBase16 (this.numberToBE (signature['v']))
+        const signature = this.signMessage(message, privateKey)
+        return signature['r'] + this.remove0xPrefix(signature['s']) + this.binaryToBase16(this.numberToBE(signature['v']))
     }
 
-    parseNumber (value, d = undefined) {
+    parseNumber(value, d = undefined) {
         if (value === undefined) {
             return d
         } else {
             try {
-                return this.number (value)
+                return this.number(value)
             } catch (e) {
                 return d
             }
         }
     }
 
-    checkOrderArguments (market, type, side, amount, price, params) {
+    checkOrderArguments(market, type, side, amount, price, params) {
         if (price === undefined) {
             if (type === 'limit') {
-                  throw new ArgumentsRequired (this.id + ' createOrder() requires a price argument for a limit order');
+                throw new ArgumentsRequired(this.id + ' createOrder() requires a price argument for a limit order');
             }
         }
         if (amount <= 0) {
-            throw new ArgumentsRequired (this.id + ' createOrder() amount should be above 0');
+            throw new ArgumentsRequired(this.id + ' createOrder() amount should be above 0');
         }
     }
 
-    handleHttpStatusCode (code, reason, url, method, body) {
-        const codeAsString = code.toString ();
+    handleHttpStatusCode(code, reason, url, method, body) {
+        const codeAsString = code.toString();
         if (codeAsString in this.httpExceptions) {
             const ErrorClass = this.httpExceptions[codeAsString];
-            throw new ErrorClass (this.id + ' ' + method + ' ' + url + ' ' + codeAsString + ' ' + reason + ' ' + body);
+            throw new ErrorClass(this.id + ' ' + method + ' ' + url + ' ' + codeAsString + ' ' + reason + ' ' + body);
         }
     }
 
@@ -802,7 +802,7 @@ module.exports = class Exchange {
     // ------------------------------------------------------------------------
     // METHODS BELOW THIS LINE ARE TRANSPILED FROM JAVASCRIPT TO PYTHON AND PHP
 
-    getDefaultOptions () {
+    getDefaultOptions() {
         return {
             'defaultNetworkCodeReplacements': {
                 'ETH': { 'ERC20': 'ETH' },
@@ -812,119 +812,119 @@ module.exports = class Exchange {
         };
     }
 
-    safeLedgerEntry (entry, currency = undefined) {
-        currency = this.safeCurrency (undefined, currency);
-        let direction = this.safeString (entry, 'direction');
-        let before = this.safeString (entry, 'before');
-        let after = this.safeString (entry, 'after');
-        const amount = this.safeString (entry, 'amount');
+    safeLedgerEntry(entry, currency = undefined) {
+        currency = this.safeCurrency(undefined, currency);
+        let direction = this.safeString(entry, 'direction');
+        let before = this.safeString(entry, 'before');
+        let after = this.safeString(entry, 'after');
+        const amount = this.safeString(entry, 'amount');
         if (amount !== undefined) {
             if (before === undefined && after !== undefined) {
-                before = Precise.stringSub (after, amount);
+                before = Precise.stringSub(after, amount);
             } else if (before !== undefined && after === undefined) {
-                after = Precise.stringAdd (before, amount);
+                after = Precise.stringAdd(before, amount);
             }
         }
         if (before !== undefined && after !== undefined) {
             if (direction === undefined) {
-                if (Precise.stringGt (before, after)) {
+                if (Precise.stringGt(before, after)) {
                     direction = 'out';
                 }
-                if (Precise.stringGt (after, before)) {
+                if (Precise.stringGt(after, before)) {
                     direction = 'in';
                 }
             }
         }
-        const fee = this.safeValue (entry, 'fee');
+        const fee = this.safeValue(entry, 'fee');
         if (fee !== undefined) {
-            fee['cost'] = this.safeNumber (fee, 'cost');
+            fee['cost'] = this.safeNumber(fee, 'cost');
         }
-        const timestamp = this.safeInteger (entry, 'timestamp');
+        const timestamp = this.safeInteger(entry, 'timestamp');
         return {
-            'id': this.safeString (entry, 'id'),
+            'id': this.safeString(entry, 'id'),
             'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'datetime': this.iso8601(timestamp),
             'direction': direction,
-            'account': this.safeString (entry, 'account'),
-            'referenceId': this.safeString (entry, 'referenceId'),
-            'referenceAccount': this.safeString (entry, 'referenceAccount'),
-            'type': this.safeString (entry, 'type'),
+            'account': this.safeString(entry, 'account'),
+            'referenceId': this.safeString(entry, 'referenceId'),
+            'referenceAccount': this.safeString(entry, 'referenceAccount'),
+            'type': this.safeString(entry, 'type'),
             'currency': currency['code'],
-            'amount': this.parseNumber (amount),
-            'before': this.parseNumber (before),
-            'after': this.parseNumber (after),
-            'status': this.safeString (entry, 'status'),
+            'amount': this.parseNumber(amount),
+            'before': this.parseNumber(before),
+            'after': this.parseNumber(after),
+            'status': this.safeString(entry, 'status'),
             'fee': fee,
             'info': entry,
         };
     }
 
-    setMarkets (markets, currencies = undefined) {
+    setMarkets(markets, currencies = undefined) {
         const values = [];
         this.markets_by_id = {};
         // handle marketId conflicts
         // we insert spot markets first
-        const marketValues = this.sortBy (this.toArray (markets), 'spot', true);
+        const marketValues = this.sortBy(this.toArray(markets), 'spot', true);
         for (let i = 0; i < marketValues.length; i++) {
             const value = marketValues[i];
             if (value['id'] in this.markets_by_id) {
-                this.markets_by_id[value['id']].push (value);
+                this.markets_by_id[value['id']].push(value);
             } else {
-                this.markets_by_id[value['id']] = [ value ];
+                this.markets_by_id[value['id']] = [value];
             }
-            const market = this.deepExtend (this.safeMarket (), {
+            const market = this.deepExtend(this.safeMarket(), {
                 'precision': this.precision,
                 'limits': this.limits,
             }, this.fees['trading'], value);
-            values.push (market);
+            values.push(market);
         }
-        this.markets = this.indexBy (values, 'symbol');
-        const marketsSortedBySymbol = this.keysort (this.markets);
-        const marketsSortedById = this.keysort (this.markets_by_id);
-        this.symbols = Object.keys (marketsSortedBySymbol);
-        this.ids = Object.keys (marketsSortedById);
+        this.markets = this.indexBy(values, 'symbol');
+        const marketsSortedBySymbol = this.keysort(this.markets);
+        const marketsSortedById = this.keysort(this.markets_by_id);
+        this.symbols = Object.keys(marketsSortedBySymbol);
+        this.ids = Object.keys(marketsSortedById);
         if (currencies !== undefined) {
-            this.currencies = this.deepExtend (this.currencies, currencies);
+            this.currencies = this.deepExtend(this.currencies, currencies);
         } else {
             let baseCurrencies = [];
             let quoteCurrencies = [];
             for (let i = 0; i < values.length; i++) {
                 const market = values[i];
-                const defaultCurrencyPrecision = (this.precisionMode === DECIMAL_PLACES) ? 8 : this.parseNumber ('1e-8');
-                const marketPrecision = this.safeValue (market, 'precision', {});
+                const defaultCurrencyPrecision = (this.precisionMode === DECIMAL_PLACES) ? 8 : this.parseNumber('1e-8');
+                const marketPrecision = this.safeValue(market, 'precision', {});
                 if ('base' in market) {
-                    const currencyPrecision = this.safeValue2 (marketPrecision, 'base', 'amount', defaultCurrencyPrecision);
+                    const currencyPrecision = this.safeValue2(marketPrecision, 'base', 'amount', defaultCurrencyPrecision);
                     const currency = {
-                        'id': this.safeString2 (market, 'baseId', 'base'),
-                        'numericId': this.safeString (market, 'baseNumericId'),
-                        'code': this.safeString (market, 'base'),
+                        'id': this.safeString2(market, 'baseId', 'base'),
+                        'numericId': this.safeString(market, 'baseNumericId'),
+                        'code': this.safeString(market, 'base'),
                         'precision': currencyPrecision,
                     };
-                    baseCurrencies.push (currency);
+                    baseCurrencies.push(currency);
                 }
                 if ('quote' in market) {
-                    const currencyPrecision = this.safeValue2 (marketPrecision, 'quote', 'price', defaultCurrencyPrecision);
+                    const currencyPrecision = this.safeValue2(marketPrecision, 'quote', 'price', defaultCurrencyPrecision);
                     const currency = {
-                        'id': this.safeString2 (market, 'quoteId', 'quote'),
-                        'numericId': this.safeString (market, 'quoteNumericId'),
-                        'code': this.safeString (market, 'quote'),
+                        'id': this.safeString2(market, 'quoteId', 'quote'),
+                        'numericId': this.safeString(market, 'quoteNumericId'),
+                        'code': this.safeString(market, 'quote'),
                         'precision': currencyPrecision,
                     };
-                    quoteCurrencies.push (currency);
+                    quoteCurrencies.push(currency);
                 }
             }
-            baseCurrencies = this.sortBy (baseCurrencies, 'code');
-            quoteCurrencies = this.sortBy (quoteCurrencies, 'code');
-            this.baseCurrencies = this.indexBy (baseCurrencies, 'code');
-            this.quoteCurrencies = this.indexBy (quoteCurrencies, 'code');
-            const allCurrencies = this.arrayConcat (baseCurrencies, quoteCurrencies);
-            const groupedCurrencies = this.groupBy (allCurrencies, 'code');
-            const codes = Object.keys (groupedCurrencies);
+            baseCurrencies = this.sortBy(baseCurrencies, 'code');
+            quoteCurrencies = this.sortBy(quoteCurrencies, 'code');
+            this.baseCurrencies = this.indexBy(baseCurrencies, 'code');
+            this.quoteCurrencies = this.indexBy(quoteCurrencies, 'code');
+            const allCurrencies = this.arrayConcat(baseCurrencies, quoteCurrencies);
+            const groupedCurrencies = this.groupBy(allCurrencies, 'code');
+            const codes = Object.keys(groupedCurrencies);
             const resultingCurrencies = [];
             for (let i = 0; i < codes.length; i++) {
                 const code = codes[i];
-                const groupedCurrenciesCode = this.safeValue (groupedCurrencies, code, []);
-                let highestPrecisionCurrency = this.safeValue (groupedCurrenciesCode, 0);
+                const groupedCurrenciesCode = this.safeValue(groupedCurrencies, code, []);
+                let highestPrecisionCurrency = this.safeValue(groupedCurrenciesCode, 0);
                 for (let j = 1; j < groupedCurrenciesCode.length; j++) {
                     const currentCurrency = groupedCurrenciesCode[j];
                     if (this.precisionMode === TICK_SIZE) {
@@ -933,51 +933,51 @@ module.exports = class Exchange {
                         highestPrecisionCurrency = (currentCurrency['precision'] > highestPrecisionCurrency['precision']) ? currentCurrency : highestPrecisionCurrency;
                     }
                 }
-                resultingCurrencies.push (highestPrecisionCurrency);
+                resultingCurrencies.push(highestPrecisionCurrency);
             }
-            const sortedCurrencies = this.sortBy (resultingCurrencies, 'code');
-            this.currencies = this.deepExtend (this.currencies, this.indexBy (sortedCurrencies, 'code'));
+            const sortedCurrencies = this.sortBy(resultingCurrencies, 'code');
+            this.currencies = this.deepExtend(this.currencies, this.indexBy(sortedCurrencies, 'code'));
         }
-        this.currencies_by_id = this.indexBy (this.currencies, 'id');
-        const currenciesSortedByCode = this.keysort (this.currencies);
-        this.codes = Object.keys (currenciesSortedByCode);
+        this.currencies_by_id = this.indexBy(this.currencies, 'id');
+        const currenciesSortedByCode = this.keysort(this.currencies);
+        this.codes = Object.keys(currenciesSortedByCode);
         return this.markets;
     }
 
-    safeBalance (balance) {
-        const balances = this.omit (balance, [ 'info', 'timestamp', 'datetime', 'free', 'used', 'total' ]);
-        const codes = Object.keys (balances);
+    safeBalance(balance) {
+        const balances = this.omit(balance, ['info', 'timestamp', 'datetime', 'free', 'used', 'total']);
+        const codes = Object.keys(balances);
         balance['free'] = {};
         balance['used'] = {};
         balance['total'] = {};
         const debtBalance = {};
         for (let i = 0; i < codes.length; i++) {
             const code = codes[i];
-            let total = this.safeString (balance[code], 'total');
-            let free = this.safeString (balance[code], 'free');
-            let used = this.safeString (balance[code], 'used');
-            const debt = this.safeString (balance[code], 'debt');
+            let total = this.safeString(balance[code], 'total');
+            let free = this.safeString(balance[code], 'free');
+            let used = this.safeString(balance[code], 'used');
+            const debt = this.safeString(balance[code], 'debt');
             if ((total === undefined) && (free !== undefined) && (used !== undefined)) {
-                total = Precise.stringAdd (free, used);
+                total = Precise.stringAdd(free, used);
             }
             if ((free === undefined) && (total !== undefined) && (used !== undefined)) {
-                free = Precise.stringSub (total, used);
+                free = Precise.stringSub(total, used);
             }
             if ((used === undefined) && (total !== undefined) && (free !== undefined)) {
-                used = Precise.stringSub (total, free);
+                used = Precise.stringSub(total, free);
             }
-            balance[code]['free'] = this.parseNumber (free);
-            balance[code]['used'] = this.parseNumber (used);
-            balance[code]['total'] = this.parseNumber (total);
+            balance[code]['free'] = this.parseNumber(free);
+            balance[code]['used'] = this.parseNumber(used);
+            balance[code]['total'] = this.parseNumber(total);
             balance['free'][code] = balance[code]['free'];
             balance['used'][code] = balance[code]['used'];
             balance['total'][code] = balance[code]['total'];
             if (debt !== undefined) {
-                balance[code]['debt'] = this.parseNumber (debt);
+                balance[code]['debt'] = this.parseNumber(debt);
                 debtBalance[code] = balance[code]['debt'];
             }
         }
-        const debtBalanceArray = Object.keys (debtBalance);
+        const debtBalanceArray = Object.keys(debtBalance);
         const length = debtBalanceArray.length;
         if (length) {
             balance['debt'] = debtBalance;
@@ -985,38 +985,38 @@ module.exports = class Exchange {
         return balance;
     }
 
-    safeOrder (order, market = undefined) {
+    safeOrder(order, market = undefined) {
         // parses numbers as strings
         // * it is important pass the trades as unparsed rawTrades
-        let amount = this.omitZero (this.safeString (order, 'amount'));
-        let remaining = this.safeString (order, 'remaining');
-        let filled = this.safeString (order, 'filled');
-        let cost = this.safeString (order, 'cost');
-        let average = this.omitZero (this.safeString (order, 'average'));
-        let price = this.omitZero (this.safeString (order, 'price'));
-        let lastTradeTimeTimestamp = this.safeInteger (order, 'lastTradeTimestamp');
-        let symbol = this.safeString (order, 'symbol');
-        let side = this.safeString (order, 'side');
+        let amount = this.omitZero(this.safeString(order, 'amount'));
+        let remaining = this.safeString(order, 'remaining');
+        let filled = this.safeString(order, 'filled');
+        let cost = this.safeString(order, 'cost');
+        let average = this.omitZero(this.safeString(order, 'average'));
+        let price = this.omitZero(this.safeString(order, 'price'));
+        let lastTradeTimeTimestamp = this.safeInteger(order, 'lastTradeTimestamp');
+        let symbol = this.safeString(order, 'symbol');
+        let side = this.safeString(order, 'side');
         const parseFilled = (filled === undefined);
         const parseCost = (cost === undefined);
         const parseLastTradeTimeTimestamp = (lastTradeTimeTimestamp === undefined);
-        const fee = this.safeValue (order, 'fee');
+        const fee = this.safeValue(order, 'fee');
         const parseFee = (fee === undefined);
-        const parseFees = this.safeValue (order, 'fees') === undefined;
+        const parseFees = this.safeValue(order, 'fees') === undefined;
         const parseSymbol = symbol === undefined;
         const parseSide = side === undefined;
         const shouldParseFees = parseFee || parseFees;
-        const fees = this.safeValue (order, 'fees', []);
+        const fees = this.safeValue(order, 'fees', []);
         let trades = [];
         if (parseFilled || parseCost || shouldParseFees) {
-            const rawTrades = this.safeValue (order, 'trades', trades);
+            const rawTrades = this.safeValue(order, 'trades', trades);
             const oldNumber = this.number;
             // we parse trades as strings here!
             this.number = String;
-            trades = this.parseTrades (rawTrades, market);
+            trades = this.parseTrades(rawTrades, market);
             this.number = oldNumber;
             let tradesLength = 0;
-            const isArray = Array.isArray (trades);
+            const isArray = Array.isArray(trades);
             if (isArray) {
                 tradesLength = trades.length;
             }
@@ -1042,39 +1042,39 @@ module.exports = class Exchange {
                 }
                 for (let i = 0; i < trades.length; i++) {
                     const trade = trades[i];
-                    const tradeAmount = this.safeString (trade, 'amount');
+                    const tradeAmount = this.safeString(trade, 'amount');
                     if (parseFilled && (tradeAmount !== undefined)) {
-                        filled = Precise.stringAdd (filled, tradeAmount);
+                        filled = Precise.stringAdd(filled, tradeAmount);
                     }
-                    const tradeCost = this.safeString (trade, 'cost');
+                    const tradeCost = this.safeString(trade, 'cost');
                     if (parseCost && (tradeCost !== undefined)) {
-                        cost = Precise.stringAdd (cost, tradeCost);
+                        cost = Precise.stringAdd(cost, tradeCost);
                     }
                     if (parseSymbol) {
-                        symbol = this.safeString (trade, 'symbol');
+                        symbol = this.safeString(trade, 'symbol');
                     }
                     if (parseSide) {
-                        side = this.safeString (trade, 'side');
+                        side = this.safeString(trade, 'side');
                     }
-                    const tradeTimestamp = this.safeValue (trade, 'timestamp');
+                    const tradeTimestamp = this.safeValue(trade, 'timestamp');
                     if (parseLastTradeTimeTimestamp && (tradeTimestamp !== undefined)) {
                         if (lastTradeTimeTimestamp === undefined) {
                             lastTradeTimeTimestamp = tradeTimestamp;
                         } else {
-                            lastTradeTimeTimestamp = Math.max (lastTradeTimeTimestamp, tradeTimestamp);
+                            lastTradeTimeTimestamp = Math.max(lastTradeTimeTimestamp, tradeTimestamp);
                         }
                     }
                     if (shouldParseFees) {
-                        const tradeFees = this.safeValue (trade, 'fees');
+                        const tradeFees = this.safeValue(trade, 'fees');
                         if (tradeFees !== undefined) {
                             for (let j = 0; j < tradeFees.length; j++) {
                                 const tradeFee = tradeFees[j];
-                                fees.push (this.extend ({}, tradeFee));
+                                fees.push(this.extend({}, tradeFee));
                             }
                         } else {
-                            const tradeFee = this.safeValue (trade, 'fee');
+                            const tradeFee = this.safeValue(trade, 'fee');
                             if (tradeFee !== undefined) {
-                                fees.push (this.extend ({}, tradeFee));
+                                fees.push(this.extend({}, tradeFee));
                             }
                         }
                     }
@@ -1082,20 +1082,20 @@ module.exports = class Exchange {
             }
         }
         if (shouldParseFees) {
-            const reducedFees = this.reduceFees ? this.reduceFeesByCurrency (fees) : fees;
+            const reducedFees = this.reduceFees ? this.reduceFeesByCurrency(fees) : fees;
             const reducedLength = reducedFees.length;
             for (let i = 0; i < reducedLength; i++) {
-                reducedFees[i]['cost'] = this.safeNumber (reducedFees[i], 'cost');
+                reducedFees[i]['cost'] = this.safeNumber(reducedFees[i], 'cost');
                 if ('rate' in reducedFees[i]) {
-                    reducedFees[i]['rate'] = this.safeNumber (reducedFees[i], 'rate');
+                    reducedFees[i]['rate'] = this.safeNumber(reducedFees[i], 'rate');
                 }
             }
             if (!parseFee && (reducedLength === 0)) {
-                fee['cost'] = this.safeNumber (fee, 'cost');
+                fee['cost'] = this.safeNumber(fee, 'cost');
                 if ('rate' in fee) {
-                    fee['rate'] = this.safeNumber (fee, 'rate');
+                    fee['rate'] = this.safeNumber(fee, 'rate');
                 }
-                reducedFees.push (fee);
+                reducedFees.push(fee);
             }
             order['fees'] = reducedFees;
             if (parseFee && (reducedLength === 1)) {
@@ -1105,36 +1105,36 @@ module.exports = class Exchange {
         if (amount === undefined) {
             // ensure amount = filled + remaining
             if (filled !== undefined && remaining !== undefined) {
-                amount = Precise.stringAdd (filled, remaining);
-            } else if (this.safeString (order, 'status') === 'closed') {
+                amount = Precise.stringAdd(filled, remaining);
+            } else if (this.safeString(order, 'status') === 'closed') {
                 amount = filled;
             }
         }
         if (filled === undefined) {
             if (amount !== undefined && remaining !== undefined) {
-                filled = Precise.stringSub (amount, remaining);
+                filled = Precise.stringSub(amount, remaining);
             }
         }
         if (remaining === undefined) {
             if (amount !== undefined && filled !== undefined) {
-                remaining = Precise.stringSub (amount, filled);
+                remaining = Precise.stringSub(amount, filled);
             }
         }
         // ensure that the average field is calculated correctly
-        const inverse = this.safeValue (market, 'inverse', false);
-        const contractSize = this.numberToString (this.safeValue (market, 'contractSize', 1));
+        const inverse = this.safeValue(market, 'inverse', false);
+        const contractSize = this.numberToString(this.safeValue(market, 'contractSize', 1));
         // inverse
         // price = filled * contract size / cost
         //
         // linear
         // price = cost / (filled * contract size)
         if (average === undefined) {
-            if ((filled !== undefined) && (cost !== undefined) && Precise.stringGt (filled, '0')) {
-                const filledTimesContractSize = Precise.stringMul (filled, contractSize);
+            if ((filled !== undefined) && (cost !== undefined) && Precise.stringGt(filled, '0')) {
+                const filledTimesContractSize = Precise.stringMul(filled, contractSize);
                 if (inverse) {
-                    average = Precise.stringDiv (filledTimesContractSize, cost);
+                    average = Precise.stringDiv(filledTimesContractSize, cost);
                 } else {
-                    average = Precise.stringDiv (cost, filledTimesContractSize);
+                    average = Precise.stringDiv(cost, filledTimesContractSize);
                 }
             }
         }
@@ -1153,37 +1153,37 @@ module.exports = class Exchange {
                 multiplyPrice = average;
             }
             // contract trading
-            const filledTimesContractSize = Precise.stringMul (filled, contractSize);
+            const filledTimesContractSize = Precise.stringMul(filled, contractSize);
             if (inverse) {
-                cost = Precise.stringDiv (filledTimesContractSize, multiplyPrice);
+                cost = Precise.stringDiv(filledTimesContractSize, multiplyPrice);
             } else {
-                cost = Precise.stringMul (filledTimesContractSize, multiplyPrice);
+                cost = Precise.stringMul(filledTimesContractSize, multiplyPrice);
             }
         }
         // support for market orders
-        const orderType = this.safeValue (order, 'type');
-        const emptyPrice = (price === undefined) || Precise.stringEquals (price, '0');
+        const orderType = this.safeValue(order, 'type');
+        const emptyPrice = (price === undefined) || Precise.stringEquals(price, '0');
         if (emptyPrice && (orderType === 'market')) {
             price = average;
         }
         // we have trades with string values at this point so we will mutate them
         for (let i = 0; i < trades.length; i++) {
             const entry = trades[i];
-            entry['amount'] = this.safeNumber (entry, 'amount');
-            entry['price'] = this.safeNumber (entry, 'price');
-            entry['cost'] = this.safeNumber (entry, 'cost');
-            const fee = this.safeValue (entry, 'fee', {});
-            fee['cost'] = this.safeNumber (fee, 'cost');
+            entry['amount'] = this.safeNumber(entry, 'amount');
+            entry['price'] = this.safeNumber(entry, 'price');
+            entry['cost'] = this.safeNumber(entry, 'cost');
+            const fee = this.safeValue(entry, 'fee', {});
+            fee['cost'] = this.safeNumber(fee, 'cost');
             if ('rate' in fee) {
-                fee['rate'] = this.safeNumber (fee, 'rate');
+                fee['rate'] = this.safeNumber(fee, 'rate');
             }
             entry['fee'] = fee;
         }
-        let timeInForce = this.safeString (order, 'timeInForce');
-        let postOnly = this.safeValue (order, 'postOnly');
+        let timeInForce = this.safeString(order, 'timeInForce');
+        let postOnly = this.safeValue(order, 'postOnly');
         // timeInForceHandling
         if (timeInForce === undefined) {
-            if (this.safeString (order, 'type') === 'market') {
+            if (this.safeString(order, 'type') === 'market') {
                 timeInForce = 'IOC';
             }
             // allow postOnly override
@@ -1203,7 +1203,7 @@ module.exports = class Exchange {
             datetime = this.iso8601 (timestamp);
         }
         const triggerPrice = this.parseNumber (this.safeString2 (order, 'triggerPrice', 'stopPrice'));
-        return this.extend (order, {
+        return this.extend(order, {
             'id': this.safeString (order, 'id'),
             'clientOrderId': this.safeString (order, 'clientOrderId'),
             'timestamp': timestamp,
@@ -1212,12 +1212,12 @@ module.exports = class Exchange {
             'type': this.safeString (order, 'type'),
             'side': side,
             'lastTradeTimestamp': lastTradeTimeTimestamp,
-            'price': this.parseNumber (price),
-            'amount': this.parseNumber (amount),
-            'cost': this.parseNumber (cost),
-            'average': this.parseNumber (average),
-            'filled': this.parseNumber (filled),
-            'remaining': this.parseNumber (remaining),
+            'price': this.parseNumber(price),
+            'amount': this.parseNumber(amount),
+            'cost': this.parseNumber(cost),
+            'average': this.parseNumber(average),
+            'filled': this.parseNumber(filled),
+            'remaining': this.parseNumber(remaining),
             'timeInForce': timeInForce,
             'postOnly': postOnly,
             'trades': trades,
@@ -1229,7 +1229,7 @@ module.exports = class Exchange {
         });
     }
 
-    parseOrders (orders, market = undefined, since = undefined, limit = undefined, params = {}) {
+    parseOrders(orders, market = undefined, since = undefined, limit = undefined, params = {}) {
         //
         // the value of orders is either a dict or a list
         //
@@ -1252,38 +1252,38 @@ module.exports = class Exchange {
         //     ]
         //
         let results = [];
-        if (Array.isArray (orders)) {
+        if (Array.isArray(orders)) {
             for (let i = 0; i < orders.length; i++) {
-                const order = this.extend (this.parseOrder (orders[i], market), params);
-                results.push (order);
+                const order = this.extend(this.parseOrder(orders[i], market), params);
+                results.push(order);
             }
         } else {
-            const ids = Object.keys (orders);
+            const ids = Object.keys(orders);
             for (let i = 0; i < ids.length; i++) {
                 const id = ids[i];
-                const order = this.extend (this.parseOrder (this.extend ({ 'id': id }, orders[id]), market), params);
-                results.push (order);
+                const order = this.extend(this.parseOrder(this.extend({ 'id': id }, orders[id]), market), params);
+                results.push(order);
             }
         }
-        results = this.sortBy (results, 'timestamp');
+        results = this.sortBy(results, 'timestamp');
         const symbol = (market !== undefined) ? market['symbol'] : undefined;
         const tail = since === undefined;
-        return this.filterBySymbolSinceLimit (results, symbol, since, limit, tail);
+        return this.filterBySymbolSinceLimit(results, symbol, since, limit, tail);
     }
 
-    calculateFee (symbol, type, side, amount, price, takerOrMaker = 'taker', params = {}) {
+    calculateFee(symbol, type, side, amount, price, takerOrMaker = 'taker', params = {}) {
         if (type === 'market' && takerOrMaker === 'maker') {
-            throw new ArgumentsRequired (this.id + ' calculateFee() - you have provided incompatible arguments - "market" type order can not be "maker". Change either the "type" or the "takerOrMaker" argument to calculate the fee.');
+            throw new ArgumentsRequired(this.id + ' calculateFee() - you have provided incompatible arguments - "market" type order can not be "maker". Change either the "type" or the "takerOrMaker" argument to calculate the fee.');
         }
         const market = this.markets[symbol];
-        const feeSide = this.safeString (market, 'feeSide', 'quote');
+        const feeSide = this.safeString(market, 'feeSide', 'quote');
         let key = 'quote';
         let cost = undefined;
-        const amountString = this.numberToString (amount);
-        const priceString = this.numberToString (price);
+        const amountString = this.numberToString(amount);
+        const priceString = this.numberToString(price);
         if (feeSide === 'quote') {
             // the fee is always in quote currency
-            cost = Precise.stringMul (amountString, priceString);
+            cost = Precise.stringMul(amountString, priceString);
         } else if (feeSide === 'base') {
             // the fee is always in base currency
             cost = amountString;
@@ -1291,7 +1291,7 @@ module.exports = class Exchange {
             // the fee is always in the currency you get
             cost = amountString;
             if (side === 'sell') {
-                cost = Precise.stringMul (cost, priceString);
+                cost = Precise.stringMul(cost, priceString);
             } else {
                 key = 'base';
             }
@@ -1299,7 +1299,7 @@ module.exports = class Exchange {
             // the fee is always in the currency you give
             cost = amountString;
             if (side === 'buy') {
-                cost = Precise.stringMul (cost, priceString);
+                cost = Precise.stringMul(cost, priceString);
             } else {
                 key = 'base';
             }
@@ -1312,55 +1312,55 @@ module.exports = class Exchange {
         if (type === 'market') {
             takerOrMaker = 'taker';
         }
-        const rate = this.safeString (market, takerOrMaker);
+        const rate = this.safeString(market, takerOrMaker);
         if (cost !== undefined) {
-            cost = Precise.stringMul (cost, rate);
+            cost = Precise.stringMul(cost, rate);
         }
         return {
             'type': takerOrMaker,
             'currency': market[key],
-            'rate': this.parseNumber (rate),
-            'cost': this.parseNumber (cost),
+            'rate': this.parseNumber(rate),
+            'cost': this.parseNumber(cost),
         };
     }
 
-    safeTrade (trade, market = undefined) {
-        const amount = this.safeString (trade, 'amount');
-        const price = this.safeString (trade, 'price');
-        let cost = this.safeString (trade, 'cost');
+    safeTrade(trade, market = undefined) {
+        const amount = this.safeString(trade, 'amount');
+        const price = this.safeString(trade, 'price');
+        let cost = this.safeString(trade, 'cost');
         if (cost === undefined) {
             // contract trading
-            const contractSize = this.safeString (market, 'contractSize');
+            const contractSize = this.safeString(market, 'contractSize');
             let multiplyPrice = price;
             if (contractSize !== undefined) {
-                const inverse = this.safeValue (market, 'inverse', false);
+                const inverse = this.safeValue(market, 'inverse', false);
                 if (inverse) {
-                    multiplyPrice = Precise.stringDiv ('1', price);
+                    multiplyPrice = Precise.stringDiv('1', price);
                 }
-                multiplyPrice = Precise.stringMul (multiplyPrice, contractSize);
+                multiplyPrice = Precise.stringMul(multiplyPrice, contractSize);
             }
-            cost = Precise.stringMul (multiplyPrice, amount);
+            cost = Precise.stringMul(multiplyPrice, amount);
         }
-        const parseFee = this.safeValue (trade, 'fee') === undefined;
-        const parseFees = this.safeValue (trade, 'fees') === undefined;
+        const parseFee = this.safeValue(trade, 'fee') === undefined;
+        const parseFees = this.safeValue(trade, 'fees') === undefined;
         const shouldParseFees = parseFee || parseFees;
         const fees = [];
-        const fee = this.safeValue (trade, 'fee');
+        const fee = this.safeValue(trade, 'fee');
         if (shouldParseFees) {
-            const reducedFees = this.reduceFees ? this.reduceFeesByCurrency (fees) : fees;
+            const reducedFees = this.reduceFees ? this.reduceFeesByCurrency(fees) : fees;
             const reducedLength = reducedFees.length;
             for (let i = 0; i < reducedLength; i++) {
-                reducedFees[i]['cost'] = this.safeNumber (reducedFees[i], 'cost');
+                reducedFees[i]['cost'] = this.safeNumber(reducedFees[i], 'cost');
                 if ('rate' in reducedFees[i]) {
-                    reducedFees[i]['rate'] = this.safeNumber (reducedFees[i], 'rate');
+                    reducedFees[i]['rate'] = this.safeNumber(reducedFees[i], 'rate');
                 }
             }
             if (!parseFee && (reducedLength === 0)) {
-                fee['cost'] = this.safeNumber (fee, 'cost');
+                fee['cost'] = this.safeNumber(fee, 'cost');
                 if ('rate' in fee) {
-                    fee['rate'] = this.safeNumber (fee, 'rate');
+                    fee['rate'] = this.safeNumber(fee, 'rate');
                 }
-                reducedFees.push (fee);
+                reducedFees.push(fee);
             }
             if (parseFees) {
                 trade['fees'] = reducedFees;
@@ -1368,22 +1368,22 @@ module.exports = class Exchange {
             if (parseFee && (reducedLength === 1)) {
                 trade['fee'] = reducedFees[0];
             }
-            const tradeFee = this.safeValue (trade, 'fee');
+            const tradeFee = this.safeValue(trade, 'fee');
             if (tradeFee !== undefined) {
-                tradeFee['cost'] = this.safeNumber (tradeFee, 'cost');
+                tradeFee['cost'] = this.safeNumber(tradeFee, 'cost');
                 if ('rate' in tradeFee) {
-                    tradeFee['rate'] = this.safeNumber (tradeFee, 'rate');
+                    tradeFee['rate'] = this.safeNumber(tradeFee, 'rate');
                 }
                 trade['fee'] = tradeFee;
             }
         }
-        trade['amount'] = this.parseNumber (amount);
-        trade['price'] = this.parseNumber (price);
-        trade['cost'] = this.parseNumber (cost);
+        trade['amount'] = this.parseNumber(amount);
+        trade['price'] = this.parseNumber(price);
+        trade['cost'] = this.parseNumber(cost);
         return trade;
     }
 
-    reduceFeesByCurrency (fees) {
+    reduceFeesByCurrency(fees) {
         //
         // this function takes a list of fee structures having the following format
         //
@@ -1432,11 +1432,11 @@ module.exports = class Exchange {
         const reduced = {};
         for (let i = 0; i < fees.length; i++) {
             const fee = fees[i];
-            const feeCurrencyCode = this.safeString (fee, 'currency');
+            const feeCurrencyCode = this.safeString(fee, 'currency');
             if (feeCurrencyCode !== undefined) {
-                const rate = this.safeString (fee, 'rate');
-                const cost = this.safeValue (fee, 'cost');
-                if (Precise.stringEq (cost, '0')) {
+                const rate = this.safeString(fee, 'rate');
+                const cost = this.safeValue(fee, 'cost');
+                if (Precise.stringEq(cost, '0')) {
                     // omit zero cost fees
                     continue;
                 }
@@ -1445,7 +1445,7 @@ module.exports = class Exchange {
                 }
                 const rateKey = (rate === undefined) ? '' : rate;
                 if (rateKey in reduced[feeCurrencyCode]) {
-                    reduced[feeCurrencyCode][rateKey]['cost'] = Precise.stringAdd (reduced[feeCurrencyCode][rateKey]['cost'], cost);
+                    reduced[feeCurrencyCode][rateKey]['cost'] = Precise.stringAdd(reduced[feeCurrencyCode][rateKey]['cost'], cost);
                 } else {
                     reduced[feeCurrencyCode][rateKey] = {
                         'currency': feeCurrencyCode,
@@ -1458,26 +1458,26 @@ module.exports = class Exchange {
             }
         }
         let result = [];
-        const feeValues = Object.values (reduced);
+        const feeValues = Object.values(reduced);
         for (let i = 0; i < feeValues.length; i++) {
-            const reducedFeeValues = Object.values (feeValues[i]);
-            result = this.arrayConcat (result, reducedFeeValues);
+            const reducedFeeValues = Object.values(feeValues[i]);
+            result = this.arrayConcat(result, reducedFeeValues);
         }
         return result;
     }
 
-    safeTicker (ticker, market = undefined) {
-        let open = this.safeValue (ticker, 'open');
-        let close = this.safeValue (ticker, 'close');
-        let last = this.safeValue (ticker, 'last');
-        let change = this.safeValue (ticker, 'change');
-        let percentage = this.safeValue (ticker, 'percentage');
-        let average = this.safeValue (ticker, 'average');
-        let vwap = this.safeValue (ticker, 'vwap');
-        const baseVolume = this.safeValue (ticker, 'baseVolume');
-        const quoteVolume = this.safeValue (ticker, 'quoteVolume');
+    safeTicker(ticker, market = undefined) {
+        let open = this.safeValue(ticker, 'open');
+        let close = this.safeValue(ticker, 'close');
+        let last = this.safeValue(ticker, 'last');
+        let change = this.safeValue(ticker, 'change');
+        let percentage = this.safeValue(ticker, 'percentage');
+        let average = this.safeValue(ticker, 'average');
+        let vwap = this.safeValue(ticker, 'vwap');
+        const baseVolume = this.safeValue(ticker, 'baseVolume');
+        const quoteVolume = this.safeValue(ticker, 'quoteVolume');
         if (vwap === undefined) {
-            vwap = Precise.stringDiv (quoteVolume, baseVolume);
+            vwap = Precise.stringDiv(quoteVolume, baseVolume);
         }
         if ((last !== undefined) && (close === undefined)) {
             close = last;
@@ -1486,86 +1486,86 @@ module.exports = class Exchange {
         }
         if ((last !== undefined) && (open !== undefined)) {
             if (change === undefined) {
-                change = Precise.stringSub (last, open);
+                change = Precise.stringSub(last, open);
             }
             if (average === undefined) {
-                average = Precise.stringDiv (Precise.stringAdd (last, open), '2');
+                average = Precise.stringDiv(Precise.stringAdd(last, open), '2');
             }
         }
-        if ((percentage === undefined) && (change !== undefined) && (open !== undefined) && Precise.stringGt (open, '0')) {
-            percentage = Precise.stringMul (Precise.stringDiv (change, open), '100');
+        if ((percentage === undefined) && (change !== undefined) && (open !== undefined) && Precise.stringGt(open, '0')) {
+            percentage = Precise.stringMul(Precise.stringDiv(change, open), '100');
         }
         if ((change === undefined) && (percentage !== undefined) && (open !== undefined)) {
-            change = Precise.stringDiv (Precise.stringMul (percentage, open), '100');
+            change = Precise.stringDiv(Precise.stringMul(percentage, open), '100');
         }
         if ((open === undefined) && (last !== undefined) && (change !== undefined)) {
-            open = Precise.stringSub (last, change);
+            open = Precise.stringSub(last, change);
         }
         // timestamp and symbol operations don't belong in safeTicker
         // they should be done in the derived classes
-        return this.extend (ticker, {
-            'bid': this.safeNumber (ticker, 'bid'),
-            'bidVolume': this.safeNumber (ticker, 'bidVolume'),
-            'ask': this.safeNumber (ticker, 'ask'),
-            'askVolume': this.safeNumber (ticker, 'askVolume'),
-            'high': this.safeNumber (ticker, 'high'),
-            'low': this.safeNumber (ticker, 'low'),
-            'open': this.parseNumber (open),
-            'close': this.parseNumber (close),
-            'last': this.parseNumber (last),
-            'change': this.parseNumber (change),
-            'percentage': this.parseNumber (percentage),
-            'average': this.parseNumber (average),
-            'vwap': this.parseNumber (vwap),
-            'baseVolume': this.parseNumber (baseVolume),
-            'quoteVolume': this.parseNumber (quoteVolume),
-            'previousClose': this.safeNumber (ticker, 'previousClose'),
+        return this.extend(ticker, {
+            'bid': this.safeNumber(ticker, 'bid'),
+            'bidVolume': this.safeNumber(ticker, 'bidVolume'),
+            'ask': this.safeNumber(ticker, 'ask'),
+            'askVolume': this.safeNumber(ticker, 'askVolume'),
+            'high': this.safeNumber(ticker, 'high'),
+            'low': this.safeNumber(ticker, 'low'),
+            'open': this.parseNumber(open),
+            'close': this.parseNumber(close),
+            'last': this.parseNumber(last),
+            'change': this.parseNumber(change),
+            'percentage': this.parseNumber(percentage),
+            'average': this.parseNumber(average),
+            'vwap': this.parseNumber(vwap),
+            'baseVolume': this.parseNumber(baseVolume),
+            'quoteVolume': this.parseNumber(quoteVolume),
+            'previousClose': this.safeNumber(ticker, 'previousClose'),
         });
     }
 
-    async fetchOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+    async fetchOHLCV(symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         if (!this.has['fetchTrades']) {
-            throw new NotSupported (this.id + ' fetchOHLCV() is not supported yet');
+            throw new NotSupported(this.id + ' fetchOHLCV() is not supported yet');
         }
-        await this.loadMarkets ();
-        const trades = await this.fetchTrades (symbol, since, limit, params);
-        const ohlcvc = this.buildOHLCVC (trades, timeframe, since, limit);
+        await this.loadMarkets();
+        const trades = await this.fetchTrades(symbol, since, limit, params);
+        const ohlcvc = this.buildOHLCVC(trades, timeframe, since, limit);
         const result = [];
         for (let i = 0; i < ohlcvc.length; i++) {
-            result.push ([
-                this.safeInteger (ohlcvc[i], 0),
-                this.safeNumber (ohlcvc[i], 1),
-                this.safeNumber (ohlcvc[i], 2),
-                this.safeNumber (ohlcvc[i], 3),
-                this.safeNumber (ohlcvc[i], 4),
-                this.safeNumber (ohlcvc[i], 5),
+            result.push([
+                this.safeInteger(ohlcvc[i], 0),
+                this.safeNumber(ohlcvc[i], 1),
+                this.safeNumber(ohlcvc[i], 2),
+                this.safeNumber(ohlcvc[i], 3),
+                this.safeNumber(ohlcvc[i], 4),
+                this.safeNumber(ohlcvc[i], 5),
             ]);
         }
         return result;
     }
 
-    convertTradingViewToOHLCV (ohlcvs, timestamp = 't', open = 'o', high = 'h', low = 'l', close = 'c', volume = 'v', ms = false) {
+    convertTradingViewToOHLCV(ohlcvs, timestamp = 't', open = 'o', high = 'h', low = 'l', close = 'c', volume = 'v', ms = false) {
         const result = [];
-        const timestamps = this.safeValue (ohlcvs, timestamp, []);
-        const opens = this.safeValue (ohlcvs, open, []);
-        const highs = this.safeValue (ohlcvs, high, []);
-        const lows = this.safeValue (ohlcvs, low, []);
-        const closes = this.safeValue (ohlcvs, close, []);
-        const volumes = this.safeValue (ohlcvs, volume, []);
+        const timestamps = this.safeValue(ohlcvs, timestamp, []);
+        const opens = this.safeValue(ohlcvs, open, []);
+        const highs = this.safeValue(ohlcvs, high, []);
+        const lows = this.safeValue(ohlcvs, low, []);
+        const closes = this.safeValue(ohlcvs, close, []);
+        const volumes = this.safeValue(ohlcvs, volume, []);
         for (let i = 0; i < timestamps.length; i++) {
-            result.push ([
-                ms ? this.safeInteger (timestamps, i) : this.safeTimestamp (timestamps, i),
-                this.safeValue (opens, i),
-                this.safeValue (highs, i),
-                this.safeValue (lows, i),
-                this.safeValue (closes, i),
-                this.safeValue (volumes, i),
+            result.push([
+                ms ? this.safeInteger(timestamps, i) : this.safeTimestamp(timestamps, i),
+                this.safeValue(opens, i),
+                this.safeValue(highs, i),
+                this.safeValue(lows, i),
+                this.safeValue(closes, i),
+                this.safeValue(volumes, i),
             ]);
         }
         return result;
     }
 
-    convertOHLCVToTradingView (ohlcvs, timestamp = 't', open = 'o', high = 'h', low = 'l', close = 'c', volume = 'v', ms = false) {
+    convertOHLCVToTradingView(ohlcvs, timestamp = 't', open = 'o', high = 'h', low = 'l', close = 'c', volume = 'v', ms = false) {
         const result = {};
         result[timestamp] = [];
         result[open] = [];
@@ -1574,97 +1574,97 @@ module.exports = class Exchange {
         result[close] = [];
         result[volume] = [];
         for (let i = 0; i < ohlcvs.length; i++) {
-            const ts = ms ? ohlcvs[i][0] : parseInt (ohlcvs[i][0] / 1000);
-            result[timestamp].push (ts);
-            result[open].push (ohlcvs[i][1]);
-            result[high].push (ohlcvs[i][2]);
-            result[low].push (ohlcvs[i][3]);
-            result[close].push (ohlcvs[i][4]);
-            result[volume].push (ohlcvs[i][5]);
+            const ts = ms ? ohlcvs[i][0] : parseInt(ohlcvs[i][0] / 1000);
+            result[timestamp].push(ts);
+            result[open].push(ohlcvs[i][1]);
+            result[high].push(ohlcvs[i][2]);
+            result[low].push(ohlcvs[i][3]);
+            result[close].push(ohlcvs[i][4]);
+            result[volume].push(ohlcvs[i][5]);
         }
         return result;
     }
 
-    marketIds (symbols) {
+    marketIds(symbols) {
         if (symbols === undefined) {
             return symbols;
         }
         const result = [];
         for (let i = 0; i < symbols.length; i++) {
-            result.push (this.marketId (symbols[i]));
+            result.push(this.marketId(symbols[i]));
         }
         return result;
     }
 
-    marketSymbols (symbols) {
+    marketSymbols(symbols) {
         if (symbols === undefined) {
             return symbols;
         }
         const result = [];
         for (let i = 0; i < symbols.length; i++) {
-            result.push (this.symbol (symbols[i]));
+            result.push(this.symbol(symbols[i]));
         }
         return result;
     }
 
-    marketCodes (codes) {
+    marketCodes(codes) {
         if (codes === undefined) {
             return codes;
         }
         const result = [];
         for (let i = 0; i < codes.length; i++) {
-            result.push (this.commonCurrencyCode (codes[i]));
+            result.push(this.commonCurrencyCode(codes[i]));
         }
         return result;
     }
 
-    parseBidsAsks (bidasks, priceKey = 0, amountKey = 1) {
-        bidasks = this.toArray (bidasks);
+    parseBidsAsks(bidasks, priceKey = 0, amountKey = 1) {
+        bidasks = this.toArray(bidasks);
         const result = [];
         for (let i = 0; i < bidasks.length; i++) {
-            result.push (this.parseBidAsk (bidasks[i], priceKey, amountKey));
+            result.push(this.parseBidAsk(bidasks[i], priceKey, amountKey));
         }
         return result;
     }
 
-    async fetchL2OrderBook (symbol, limit = undefined, params = {}) {
-        const orderbook = await this.fetchOrderBook (symbol, limit, params);
-        return this.extend (orderbook, {
-            'asks': this.sortBy (this.aggregate (orderbook['asks']), 0),
-            'bids': this.sortBy (this.aggregate (orderbook['bids']), 0, true),
+    async fetchL2OrderBook(symbol, limit = undefined, params = {}) {
+        const orderbook = await this.fetchOrderBook(symbol, limit, params);
+        return this.extend(orderbook, {
+            'asks': this.sortBy(this.aggregate(orderbook['asks']), 0),
+            'bids': this.sortBy(this.aggregate(orderbook['bids']), 0, true),
         });
     }
 
-    filterBySymbol (objects, symbol = undefined) {
+    filterBySymbol(objects, symbol = undefined) {
         if (symbol === undefined) {
             return objects;
         }
         const result = [];
         for (let i = 0; i < objects.length; i++) {
-            const objectSymbol = this.safeString (objects[i], 'symbol');
+            const objectSymbol = this.safeString(objects[i], 'symbol');
             if (objectSymbol === symbol) {
-                result.push (objects[i]);
+                result.push(objects[i]);
             }
         }
         return result;
     }
 
-    parseOHLCV (ohlcv, market = undefined) {
-        if (Array.isArray (ohlcv)) {
+    parseOHLCV(ohlcv, market = undefined) {
+        if (Array.isArray(ohlcv)) {
             return [
-                this.safeInteger (ohlcv, 0), // timestamp
-                this.safeNumber (ohlcv, 1), // open
-                this.safeNumber (ohlcv, 2), // high
-                this.safeNumber (ohlcv, 3), // low
-                this.safeNumber (ohlcv, 4), // close
-                this.safeNumber (ohlcv, 5), // volume
+                this.safeInteger(ohlcv, 0), // timestamp
+                this.safeNumber(ohlcv, 1), // open
+                this.safeNumber(ohlcv, 2), // high
+                this.safeNumber(ohlcv, 3), // low
+                this.safeNumber(ohlcv, 4), // close
+                this.safeNumber(ohlcv, 5), // volume
             ];
         }
         return ohlcv;
     }
 
-    getNetwork (network, code) {
-        network = network.toUpperCase ();
+    getNetwork(network, code) {
+        network = network.toUpperCase();
         const aliases = {
             'ETHEREUM': 'ETH',
             'ETHER': 'ETH',
@@ -1698,11 +1698,11 @@ module.exports = class Exchange {
         } else if (network in aliases) {
             return aliases[network];
         } else {
-            throw new NotSupported (this.id + ' network ' + network + ' is not yet supported');
+            throw new NotSupported(this.id + ' network ' + network + ' is not yet supported');
         }
     }
 
-    networkCodeToId (networkCode, currencyCode = undefined) {
+    networkCodeToId(networkCode, currencyCode = undefined) {
         /**
          * @ignore
          * @method
@@ -1712,8 +1712,8 @@ module.exports = class Exchange {
          * @param {string|undefined} currencyCode unified currency code, but this argument is not required by default, unless there is an exchange (like huobi) that needs an override of the method to be able to pass currencyCode argument additionally
          * @returns {[string|undefined]} exchange-specific network id
          */
-        const networkIdsByCodes = this.safeValue (this.options, 'networks', {});
-        let networkId = this.safeString (networkIdsByCodes, networkCode);
+        const networkIdsByCodes = this.safeValue(this.options, 'networks', {});
+        let networkId = this.safeString(networkIdsByCodes, networkCode);
         // for example, if 'ETH' is passed for networkCode, but 'ETH' key not defined in `options->networks` object
         if (networkId === undefined) {
             if (currencyCode === undefined) {
@@ -1721,17 +1721,17 @@ module.exports = class Exchange {
                 networkId = networkCode;
             } else {
                 // if currencyCode was provided, then we try to find if that currencyCode has a replacement (i.e. ERC20 for ETH)
-                const defaultNetworkCodeReplacements = this.safeValue (this.options, 'defaultNetworkCodeReplacements', {});
+                const defaultNetworkCodeReplacements = this.safeValue(this.options, 'defaultNetworkCodeReplacements', {});
                 if (currencyCode in defaultNetworkCodeReplacements) {
                     // if there is a replacement for the passed networkCode, then we use it to find network-id in `options->networks` object
                     const replacementObject = defaultNetworkCodeReplacements[currencyCode]; // i.e. { 'ERC20': 'ETH' }
-                    const keys = Object.keys (replacementObject);
+                    const keys = Object.keys(replacementObject);
                     for (let i = 0; i < keys.length; i++) {
                         const key = keys[i];
                         const value = replacementObject[key];
                         // if value matches to provided unified networkCode, then we use it's key to find network-id in `options->networks` object
                         if (value === networkCode) {
-                            networkId = this.safeString (networkIdsByCodes, key);
+                            networkId = this.safeString(networkIdsByCodes, key);
                             break;
                         }
                     }
@@ -1745,7 +1745,7 @@ module.exports = class Exchange {
         return networkId;
     }
 
-    networkIdToCode (networkId, currencyCode = undefined) {
+    networkIdToCode(networkId, currencyCode = undefined) {
         /**
          * @ignore
          * @method
@@ -1755,20 +1755,20 @@ module.exports = class Exchange {
          * @param {string|undefined} currencyCode unified currency code, but this argument is not required by default, unless there is an exchange (like huobi) that needs an override of the method to be able to pass currencyCode argument additionally
          * @returns {[string|undefined]} unified network code
          */
-        const networkCodesByIds = this.safeValue (this.options, 'networksById', {});
-        let networkCode = this.safeString (networkCodesByIds, networkId, networkId);
+        const networkCodesByIds = this.safeValue(this.options, 'networksById', {});
+        let networkCode = this.safeString(networkCodesByIds, networkId, networkId);
         // replace mainnet network-codes (i.e. ERC20->ETH)
         if (currencyCode !== undefined) {
-            const defaultNetworkCodeReplacements = this.safeValue (this.options, 'defaultNetworkCodeReplacements', {});
+            const defaultNetworkCodeReplacements = this.safeValue(this.options, 'defaultNetworkCodeReplacements', {});
             if (currencyCode in defaultNetworkCodeReplacements) {
-                const replacementObject = this.safeValue (defaultNetworkCodeReplacements, currencyCode, {});
-                networkCode = this.safeString (replacementObject, networkCode, networkCode);
+                const replacementObject = this.safeValue(defaultNetworkCodeReplacements, currencyCode, {});
+                networkCode = this.safeString(replacementObject, networkCode, networkCode);
             }
         }
         return networkCode;
     }
 
-    networkCodesToIds (networkCodes = undefined) {
+    networkCodesToIds(networkCodes = undefined) {
         /**
          * @ignore
          * @method
@@ -1783,29 +1783,29 @@ module.exports = class Exchange {
         const ids = [];
         for (let i = 0; i < networkCodes.length; i++) {
             const networkCode = networkCodes[i];
-            ids.push (this.networkCodeToId (networkCode));
+            ids.push(this.networkCodeToId(networkCode));
         }
         return ids;
     }
 
-    handleNetworkCodeAndParams (params) {
-        const networkCodeInParams = this.safeString2 (params, 'networkCode', 'network');
+    handleNetworkCodeAndParams(params) {
+        const networkCodeInParams = this.safeString2(params, 'networkCode', 'network');
         if (networkCodeInParams !== undefined) {
-            params = this.omit (params, [ 'networkCode', 'network' ]);
+            params = this.omit(params, ['networkCode', 'network']);
         }
         // if it was not defined by user, we should not set it from 'defaultNetworks', because handleNetworkCodeAndParams is for only request-side and thus we do not fill it with anything. We can only use 'defaultNetworks' after parsing response-side
-        return [ networkCodeInParams, params ];
+        return [networkCodeInParams, params];
     }
 
-    defaultNetworkCode (currencyCode) {
+    defaultNetworkCode(currencyCode) {
         let defaultNetworkCode = undefined;
-        const defaultNetworks = this.safeValue (this.options, 'defaultNetworks', {});
+        const defaultNetworks = this.safeValue(this.options, 'defaultNetworks', {});
         if (currencyCode in defaultNetworks) {
             // if currency had set its network in "defaultNetworks", use it
             defaultNetworkCode = defaultNetworks[currencyCode];
         } else {
             // otherwise, try to use the global-scope 'defaultNetwork' value (even if that network is not supported by currency, it doesn't make any problem, this will be just used "at first" if currency supports this network at all)
-            const defaultNetwork = this.safeValue (this.options, 'defaultNetwork');
+            const defaultNetwork = this.safeValue(this.options, 'defaultNetwork');
             if (defaultNetwork !== undefined) {
                 defaultNetworkCode = defaultNetwork;
             }
@@ -1813,237 +1813,237 @@ module.exports = class Exchange {
         return defaultNetworkCode;
     }
 
-    selectNetworkCodeFromUnifiedNetworks (currencyCode, networkCode, indexedNetworkEntries) {
-        return this.selectNetworkKeyFromNetworks (currencyCode, networkCode, indexedNetworkEntries, true);
+    selectNetworkCodeFromUnifiedNetworks(currencyCode, networkCode, indexedNetworkEntries) {
+        return this.selectNetworkKeyFromNetworks(currencyCode, networkCode, indexedNetworkEntries, true);
     }
 
-    selectNetworkIdFromRawNetworks (currencyCode, networkCode, indexedNetworkEntries) {
-        return this.selectNetworkKeyFromNetworks (currencyCode, networkCode, indexedNetworkEntries, false);
+    selectNetworkIdFromRawNetworks(currencyCode, networkCode, indexedNetworkEntries) {
+        return this.selectNetworkKeyFromNetworks(currencyCode, networkCode, indexedNetworkEntries, false);
     }
 
-    selectNetworkKeyFromNetworks (currencyCode, networkCode, indexedNetworkEntries, isIndexedByUnifiedNetworkCode = false) {
+    selectNetworkKeyFromNetworks(currencyCode, networkCode, indexedNetworkEntries, isIndexedByUnifiedNetworkCode = false) {
         // this method is used against raw & unparse network entries, which are just indexed by network id
         let chosenNetworkId = undefined;
-        const availableNetworkIds = Object.keys (indexedNetworkEntries);
+        const availableNetworkIds = Object.keys(indexedNetworkEntries);
         const responseNetworksLength = availableNetworkIds.length;
         if (networkCode !== undefined) {
             if (responseNetworksLength === 0) {
-                throw new NotSupported (this.id + ' - ' + networkCode + ' network did not return any result for ' + currencyCode);
+                throw new NotSupported(this.id + ' - ' + networkCode + ' network did not return any result for ' + currencyCode);
             } else {
                 // if networkCode was provided by user, we should check it after response, as the referenced exchange doesn't support network-code during request
-                const networkId = isIndexedByUnifiedNetworkCode ? networkCode : this.networkCodeToId (networkCode, currencyCode);
+                const networkId = isIndexedByUnifiedNetworkCode ? networkCode : this.networkCodeToId(networkCode, currencyCode);
                 if (networkId in indexedNetworkEntries) {
                     chosenNetworkId = networkId;
                 } else {
-                    throw new NotSupported (this.id + ' - ' + networkId + ' network was not found for ' + currencyCode + ', use one of ' + availableNetworkIds.join (', '));
+                    throw new NotSupported(this.id + ' - ' + networkId + ' network was not found for ' + currencyCode + ', use one of ' + availableNetworkIds.join(', '));
                 }
             }
         } else {
             if (responseNetworksLength === 0) {
-                throw new NotSupported (this.id + ' - no networks were returned for ' + currencyCode);
+                throw new NotSupported(this.id + ' - no networks were returned for ' + currencyCode);
             } else {
                 // if networkCode was not provided by user, then we try to use the default network (if it was defined in "defaultNetworks"), otherwise, we just return the first network entry
-                const defaultNetworkCode = this.defaultNetworkCode (currencyCode);
-                const defaultNetworkId = isIndexedByUnifiedNetworkCode ? defaultNetworkCode : this.networkCodeToId (defaultNetworkCode, currencyCode);
+                const defaultNetworkCode = this.defaultNetworkCode(currencyCode);
+                const defaultNetworkId = isIndexedByUnifiedNetworkCode ? defaultNetworkCode : this.networkCodeToId(defaultNetworkCode, currencyCode);
                 chosenNetworkId = (defaultNetworkId in indexedNetworkEntries) ? defaultNetworkId : availableNetworkIds[0];
             }
         }
         return chosenNetworkId;
     }
 
-    safeNumber2 (dictionary, key1, key2, d = undefined) {
-        const value = this.safeString2 (dictionary, key1, key2);
-        return this.parseNumber (value, d);
+    safeNumber2(dictionary, key1, key2, d = undefined) {
+        const value = this.safeString2(dictionary, key1, key2);
+        return this.parseNumber(value, d);
     }
 
-    parseOrderBook (orderbook, symbol, timestamp = undefined, bidsKey = 'bids', asksKey = 'asks', priceKey = 0, amountKey = 1) {
-        const bids = this.parseBidsAsks (this.safeValue (orderbook, bidsKey, []), priceKey, amountKey);
-        const asks = this.parseBidsAsks (this.safeValue (orderbook, asksKey, []), priceKey, amountKey);
+    parseOrderBook(orderbook, symbol, timestamp = undefined, bidsKey = 'bids', asksKey = 'asks', priceKey = 0, amountKey = 1) {
+        const bids = this.parseBidsAsks(this.safeValue(orderbook, bidsKey, []), priceKey, amountKey);
+        const asks = this.parseBidsAsks(this.safeValue(orderbook, asksKey, []), priceKey, amountKey);
         return {
             'symbol': symbol,
-            'bids': this.sortBy (bids, 0, true),
-            'asks': this.sortBy (asks, 0),
+            'bids': this.sortBy(bids, 0, true),
+            'asks': this.sortBy(asks, 0),
             'timestamp': timestamp,
-            'datetime': this.iso8601 (timestamp),
+            'datetime': this.iso8601(timestamp),
             'nonce': undefined,
         };
     }
 
-    parseOHLCVs (ohlcvs, market = undefined, timeframe = '1m', since = undefined, limit = undefined) {
+    parseOHLCVs(ohlcvs, market = undefined, timeframe = '1m', since = undefined, limit = undefined) {
         const results = [];
         for (let i = 0; i < ohlcvs.length; i++) {
-            results.push (this.parseOHLCV (ohlcvs[i], market));
+            results.push(this.parseOHLCV(ohlcvs[i], market));
         }
-        const sorted = this.sortBy (results, 0);
+        const sorted = this.sortBy(results, 0);
         const tail = (since === undefined);
-        return this.filterBySinceLimit (sorted, since, limit, 0, tail);
+        return this.filterBySinceLimit(sorted, since, limit, 0, tail);
     }
 
-    parseLeverageTiers (response, symbols = undefined, marketIdKey = undefined) {
+    parseLeverageTiers(response, symbols = undefined, marketIdKey = undefined) {
         // marketIdKey should only be undefined when response is a dictionary
-        symbols = this.marketSymbols (symbols);
+        symbols = this.marketSymbols(symbols);
         const tiers = {};
         for (let i = 0; i < response.length; i++) {
             const item = response[i];
-            const id = this.safeString (item, marketIdKey);
-            const market = this.safeMarket (id, undefined, undefined, this.safeString (this.options, 'defaultType'));
+            const id = this.safeString(item, marketIdKey);
+            const market = this.safeMarket(id, undefined, undefined, this.safeString(this.options, 'defaultType'));
             const symbol = market['symbol'];
-            const contract = this.safeValue (market, 'contract', false);
-            if (contract && ((symbols === undefined) || this.inArray (symbol, symbols))) {
-                tiers[symbol] = this.parseMarketLeverageTiers (item, market);
+            const contract = this.safeValue(market, 'contract', false);
+            if (contract && ((symbols === undefined) || this.inArray(symbol, symbols))) {
+                tiers[symbol] = this.parseMarketLeverageTiers(item, market);
             }
         }
         return tiers;
     }
 
-    async loadTradingLimits (symbols = undefined, reload = false, params = {}) {
+    async loadTradingLimits(symbols = undefined, reload = false, params = {}) {
         if (this.has['fetchTradingLimits']) {
             if (reload || !('limitsLoaded' in this.options)) {
-                const response = await this.fetchTradingLimits (symbols);
+                const response = await this.fetchTradingLimits(symbols);
                 for (let i = 0; i < symbols.length; i++) {
                     const symbol = symbols[i];
-                    this.markets[symbol] = this.deepExtend (this.markets[symbol], response[symbol]);
+                    this.markets[symbol] = this.deepExtend(this.markets[symbol], response[symbol]);
                 }
-                this.options['limitsLoaded'] = this.milliseconds ();
+                this.options['limitsLoaded'] = this.milliseconds();
             }
         }
         return this.markets;
     }
 
-    parsePositions (positions, symbols = undefined, params = {}) {
-        symbols = this.marketSymbols (symbols);
-        positions = this.toArray (positions);
+    parsePositions(positions, symbols = undefined, params = {}) {
+        symbols = this.marketSymbols(symbols);
+        positions = this.toArray(positions);
         const result = [];
         for (let i = 0; i < positions.length; i++) {
-            const position = this.extend (this.parsePosition (positions[i], undefined), params);
-            result.push (position);
+            const position = this.extend(this.parsePosition(positions[i], undefined), params);
+            result.push(position);
         }
-        return this.filterByArray (result, 'symbol', symbols, false);
+        return this.filterByArray(result, 'symbol', symbols, false);
     }
 
-    parseAccounts (accounts, params = {}) {
-        accounts = this.toArray (accounts);
+    parseAccounts(accounts, params = {}) {
+        accounts = this.toArray(accounts);
         const result = [];
         for (let i = 0; i < accounts.length; i++) {
-            const account = this.extend (this.parseAccount (accounts[i]), params);
-            result.push (account);
+            const account = this.extend(this.parseAccount(accounts[i]), params);
+            result.push(account);
         }
         return result;
     }
 
-    parseTrades (trades, market = undefined, since = undefined, limit = undefined, params = {}) {
-        trades = this.toArray (trades);
+    parseTrades(trades, market = undefined, since = undefined, limit = undefined, params = {}) {
+        trades = this.toArray(trades);
         let result = [];
         for (let i = 0; i < trades.length; i++) {
-            const trade = this.extend (this.parseTrade (trades[i], market), params);
-            result.push (trade);
+            const trade = this.extend(this.parseTrade(trades[i], market), params);
+            result.push(trade);
         }
-        result = this.sortBy2 (result, 'timestamp', 'id');
+        result = this.sortBy2(result, 'timestamp', 'id');
         const symbol = (market !== undefined) ? market['symbol'] : undefined;
         const tail = (since === undefined);
-        return this.filterBySymbolSinceLimit (result, symbol, since, limit, tail);
+        return this.filterBySymbolSinceLimit(result, symbol, since, limit, tail);
     }
 
-    parseTransactions (transactions, currency = undefined, since = undefined, limit = undefined, params = {}) {
-        transactions = this.toArray (transactions);
+    parseTransactions(transactions, currency = undefined, since = undefined, limit = undefined, params = {}) {
+        transactions = this.toArray(transactions);
         let result = [];
         for (let i = 0; i < transactions.length; i++) {
-            const transaction = this.extend (this.parseTransaction (transactions[i], currency), params);
-            result.push (transaction);
+            const transaction = this.extend(this.parseTransaction(transactions[i], currency), params);
+            result.push(transaction);
         }
-        result = this.sortBy (result, 'timestamp');
+        result = this.sortBy(result, 'timestamp');
         const code = (currency !== undefined) ? currency['code'] : undefined;
         const tail = (since === undefined);
-        return this.filterByCurrencySinceLimit (result, code, since, limit, tail);
+        return this.filterByCurrencySinceLimit(result, code, since, limit, tail);
     }
 
-    parseTransfers (transfers, currency = undefined, since = undefined, limit = undefined, params = {}) {
-        transfers = this.toArray (transfers);
+    parseTransfers(transfers, currency = undefined, since = undefined, limit = undefined, params = {}) {
+        transfers = this.toArray(transfers);
         let result = [];
         for (let i = 0; i < transfers.length; i++) {
-            const transfer = this.extend (this.parseTransfer (transfers[i], currency), params);
-            result.push (transfer);
+            const transfer = this.extend(this.parseTransfer(transfers[i], currency), params);
+            result.push(transfer);
         }
-        result = this.sortBy (result, 'timestamp');
+        result = this.sortBy(result, 'timestamp');
         const code = (currency !== undefined) ? currency['code'] : undefined;
         const tail = (since === undefined);
-        return this.filterByCurrencySinceLimit (result, code, since, limit, tail);
+        return this.filterByCurrencySinceLimit(result, code, since, limit, tail);
     }
 
-    parseLedger (data, currency = undefined, since = undefined, limit = undefined, params = {}) {
+    parseLedger(data, currency = undefined, since = undefined, limit = undefined, params = {}) {
         let result = [];
-        const arrayData = this.toArray (data);
+        const arrayData = this.toArray(data);
         for (let i = 0; i < arrayData.length; i++) {
-            const itemOrItems = this.parseLedgerEntry (arrayData[i], currency);
-            if (Array.isArray (itemOrItems)) {
+            const itemOrItems = this.parseLedgerEntry(arrayData[i], currency);
+            if (Array.isArray(itemOrItems)) {
                 for (let j = 0; j < itemOrItems.length; j++) {
-                    result.push (this.extend (itemOrItems[j], params));
+                    result.push(this.extend(itemOrItems[j], params));
                 }
             } else {
-                result.push (this.extend (itemOrItems, params));
+                result.push(this.extend(itemOrItems, params));
             }
         }
-        result = this.sortBy (result, 'timestamp');
+        result = this.sortBy(result, 'timestamp');
         const code = (currency !== undefined) ? currency['code'] : undefined;
         const tail = (since === undefined);
-        return this.filterByCurrencySinceLimit (result, code, since, limit, tail);
+        return this.filterByCurrencySinceLimit(result, code, since, limit, tail);
     }
 
-    nonce () {
-        return this.seconds ();
+    nonce() {
+        return this.seconds();
     }
 
-    setHeaders (headers) {
+    setHeaders(headers) {
         return headers;
     }
 
-    marketId (symbol) {
-        const market = this.market (symbol);
+    marketId(symbol) {
+        const market = this.market(symbol);
         if (market !== undefined) {
             return market['id'];
         }
         return symbol;
     }
 
-    symbol (symbol) {
-        const market = this.market (symbol);
-        return this.safeString (market, 'symbol', symbol);
+    symbol(symbol) {
+        const market = this.market(symbol);
+        return this.safeString(market, 'symbol', symbol);
     }
 
-    resolvePath (path, params) {
+    resolvePath(path, params) {
         return [
-            this.implodeParams (path, params),
-            this.omit (params, this.extractParams (path)),
+            this.implodeParams(path, params),
+            this.omit(params, this.extractParams(path)),
         ];
     }
 
-    filterByArray (objects, key, values = undefined, indexed = true) {
-        objects = this.toArray (objects);
+    filterByArray(objects, key, values = undefined, indexed = true) {
+        objects = this.toArray(objects);
         // return all of them if no values were passed
         if (values === undefined || !values) {
-            return indexed ? this.indexBy (objects, key) : objects;
+            return indexed ? this.indexBy(objects, key) : objects;
         }
         const results = [];
         for (let i = 0; i < objects.length; i++) {
-            if (this.inArray (objects[i][key], values)) {
-                results.push (objects[i]);
+            if (this.inArray(objects[i][key], values)) {
+                results.push(objects[i]);
             }
         }
-        return indexed ? this.indexBy (results, key) : results;
+        return indexed ? this.indexBy(results, key) : results;
     }
 
-    async fetch2 (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined, config = {}, context = {}) {
+    async fetch2(path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined, config = {}, context = {}) {
         if (this.enableRateLimit) {
-            const cost = this.calculateRateLimiterCost (api, method, path, params, config, context);
-            await this.throttle (cost);
+            const cost = this.calculateRateLimiterCost(api, method, path, params, config, context);
+            await this.throttle(cost, path);
         }
-        this.lastRestRequestTimestamp = this.milliseconds ();
-        const request = this.sign (path, api, method, params, headers, body);
-        return await this.fetch (request['url'], request['method'], request['headers'], request['body']);
+        this.lastRestRequestTimestamp = this.milliseconds();
+        const request = this.sign(path, api, method, params, headers, body);
+        return await this.fetch(request['url'], request['method'], request['headers'], request['body']);
     }
 
-    async request (path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined, config = {}, context = {}) {
-        return await this.fetch2 (path, api, method, params, headers, body, config, context);
+    async request(path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined, config = {}, context = {}) {
+        return await this.fetch2(path, api, method, params, headers, body, config, context);
     }
 
     async loadAccounts (reload = false, params = {}) {
@@ -2064,64 +2064,64 @@ module.exports = class Exchange {
         throw new NotSupported (this.id + ' fetchTrades() is not supported yet');
     }
 
-    async fetchOHLCVC (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+    async fetchOHLCVC(symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         if (!this.has['fetchTrades']) {
-            throw new NotSupported (this.id + ' fetchOHLCV() is not supported yet');
+            throw new NotSupported(this.id + ' fetchOHLCV() is not supported yet');
         }
-        await this.loadMarkets ();
-        const trades = await this.fetchTrades (symbol, since, limit, params);
-        return this.buildOHLCVC (trades, timeframe, since, limit);
+        await this.loadMarkets();
+        const trades = await this.fetchTrades(symbol, since, limit, params);
+        return this.buildOHLCVC(trades, timeframe, since, limit);
     }
 
-    parseTradingViewOHLCV (ohlcvs, market = undefined, timeframe = '1m', since = undefined, limit = undefined) {
-        const result = this.convertTradingViewToOHLCV (ohlcvs);
-        return this.parseOHLCVs (result, market, timeframe, since, limit);
+    parseTradingViewOHLCV(ohlcvs, market = undefined, timeframe = '1m', since = undefined, limit = undefined) {
+        const result = this.convertTradingViewToOHLCV(ohlcvs);
+        return this.parseOHLCVs(result, market, timeframe, since, limit);
     }
 
-    async editLimitBuyOrder (id, symbol, amount, price = undefined, params = {}) {
-        return await this.editLimitOrder (id, symbol, 'buy', amount, price, params);
+    async editLimitBuyOrder(id, symbol, amount, price = undefined, params = {}) {
+        return await this.editLimitOrder(id, symbol, 'buy', amount, price, params);
     }
 
-    async editLimitSellOrder (id, symbol, amount, price = undefined, params = {}) {
-        return await this.editLimitOrder (id, symbol, 'sell', amount, price, params);
+    async editLimitSellOrder(id, symbol, amount, price = undefined, params = {}) {
+        return await this.editLimitOrder(id, symbol, 'sell', amount, price, params);
     }
 
-    async editLimitOrder (id, symbol, side, amount, price = undefined, params = {}) {
-        return await this.editOrder (id, symbol, 'limit', side, amount, price, params);
+    async editLimitOrder(id, symbol, side, amount, price = undefined, params = {}) {
+        return await this.editOrder(id, symbol, 'limit', side, amount, price, params);
     }
 
-    async editOrder (id, symbol, type, side, amount, price = undefined, params = {}) {
-        await this.cancelOrder (id, symbol);
-        return await this.createOrder (symbol, type, side, amount, price, params);
+    async editOrder(id, symbol, type, side, amount, price = undefined, params = {}) {
+        await this.cancelOrder(id, symbol);
+        return await this.createOrder(symbol, type, side, amount, price, params);
     }
 
-    async fetchPermissions (params = {}) {
-        throw new NotSupported (this.id + ' fetchPermissions() is not supported yet');
+    async fetchPermissions(params = {}) {
+        throw new NotSupported(this.id + ' fetchPermissions() is not supported yet');
     }
 
-    async fetchPosition (symbol, params = {}) {
-        throw new NotSupported (this.id + ' fetchPosition() is not supported yet');
+    async fetchPosition(symbol, params = {}) {
+        throw new NotSupported(this.id + ' fetchPosition() is not supported yet');
     }
 
-    async fetchPositions (symbols = undefined, params = {}) {
-        throw new NotSupported (this.id + ' fetchPositions() is not supported yet');
+    async fetchPositions(symbols = undefined, params = {}) {
+        throw new NotSupported(this.id + ' fetchPositions() is not supported yet');
     }
 
-    async fetchPositionsRisk (symbols = undefined, params = {}) {
-        throw new NotSupported (this.id + ' fetchPositionsRisk() is not supported yet');
+    async fetchPositionsRisk(symbols = undefined, params = {}) {
+        throw new NotSupported(this.id + ' fetchPositionsRisk() is not supported yet');
     }
 
-    async fetchBidsAsks (symbols = undefined, params = {}) {
-        throw new NotSupported (this.id + ' fetchBidsAsks() is not supported yet');
+    async fetchBidsAsks(symbols = undefined, params = {}) {
+        throw new NotSupported(this.id + ' fetchBidsAsks() is not supported yet');
     }
 
-    parseBidAsk (bidask, priceKey = 0, amountKey = 1) {
-        const price = this.safeNumber (bidask, priceKey);
-        const amount = this.safeNumber (bidask, amountKey);
-        return [ price, amount ];
+    parseBidAsk(bidask, priceKey = 0, amountKey = 1) {
+        const price = this.safeNumber(bidask, priceKey);
+        const amount = this.safeNumber(bidask, amountKey);
+        return [price, amount];
     }
 
-    safeCurrency (currencyId, currency = undefined) {
+    safeCurrency(currencyId, currency = undefined) {
         if ((currencyId === undefined) && (currency !== undefined)) {
             return currency;
         }
@@ -2130,7 +2130,7 @@ module.exports = class Exchange {
         }
         let code = currencyId;
         if (currencyId !== undefined) {
-            code = this.commonCurrencyCode (currencyId.toUpperCase ());
+            code = this.commonCurrencyCode(currencyId.toUpperCase());
         }
         return {
             'id': currencyId,
@@ -2138,7 +2138,7 @@ module.exports = class Exchange {
         };
     }
 
-    safeMarket (marketId = undefined, market = undefined, delimiter = undefined, marketType = undefined) {
+    safeMarket(marketId = undefined, market = undefined, delimiter = undefined, marketType = undefined) {
         const result = {
             'id': marketId,
             'symbol': marketId,
@@ -2191,7 +2191,7 @@ module.exports = class Exchange {
                     return markets[0];
                 } else {
                     if (marketType === undefined) {
-                        throw new ArgumentsRequired (this.id + ' safeMarket() requires a fourth argument for ' + marketId + ' to disambiguate between different markets with the same market id');
+                        throw new ArgumentsRequired(this.id + ' safeMarket() requires a fourth argument for ' + marketId + ' to disambiguate between different markets with the same market id');
                     }
                     for (let i = 0; i < markets.length; i++) {
                         const market = markets[i];
@@ -2201,13 +2201,13 @@ module.exports = class Exchange {
                     }
                 }
             } else if (delimiter !== undefined) {
-                const parts = marketId.split (delimiter);
+                const parts = marketId.split(delimiter);
                 const partsLength = parts.length;
                 if (partsLength === 2) {
-                    result['baseId'] = this.safeString (parts, 0);
-                    result['quoteId'] = this.safeString (parts, 1);
-                    result['base'] = this.safeCurrencyCode (result['baseId']);
-                    result['quote'] = this.safeCurrencyCode (result['quoteId']);
+                    result['baseId'] = this.safeString(parts, 0);
+                    result['quoteId'] = this.safeString(parts, 1);
+                    result['base'] = this.safeCurrencyCode(result['baseId']);
+                    result['quote'] = this.safeCurrencyCode(result['quoteId']);
                     result['symbol'] = result['base'] + '/' + result['quote'];
                     return result;
                 } else {
@@ -2221,13 +2221,13 @@ module.exports = class Exchange {
         return result;
     }
 
-    checkRequiredCredentials (error = true) {
-        const keys = Object.keys (this.requiredCredentials);
+    checkRequiredCredentials(error = true) {
+        const keys = Object.keys(this.requiredCredentials);
         for (let i = 0; i < keys.length; i++) {
             const key = keys[i];
             if (this.requiredCredentials[key] && !this[key]) {
                 if (error) {
-                    throw new AuthenticationError (this.id + ' requires "' + key + '" credential');
+                    throw new AuthenticationError(this.id + ' requires "' + key + '" credential');
                 } else {
                     return false;
                 }
@@ -2236,123 +2236,123 @@ module.exports = class Exchange {
         return true;
     }
 
-    oath () {
+    oath() {
         if (this.twofa !== undefined) {
-            return this.totp (this.twofa);
+            return this.totp(this.twofa);
         } else {
-            throw new ExchangeError (this.id + ' exchange.twofa has not been set for 2FA Two-Factor Authentication');
+            throw new ExchangeError(this.id + ' exchange.twofa has not been set for 2FA Two-Factor Authentication');
         }
     }
 
-    async fetchBalance (params = {}) {
-        throw new NotSupported (this.id + ' fetchBalance() is not supported yet');
+    async fetchBalance(params = {}) {
+        throw new NotSupported(this.id + ' fetchBalance() is not supported yet');
     }
 
-    async fetchPartialBalance (part, params = {}) {
-        const balance = await this.fetchBalance (params);
+    async fetchPartialBalance(part, params = {}) {
+        const balance = await this.fetchBalance(params);
         return balance[part];
     }
 
-    async fetchFreeBalance (params = {}) {
-        return await this.fetchPartialBalance ('free', params);
+    async fetchFreeBalance(params = {}) {
+        return await this.fetchPartialBalance('free', params);
     }
 
-    async fetchUsedBalance (params = {}) {
-        return await this.fetchPartialBalance ('used', params);
+    async fetchUsedBalance(params = {}) {
+        return await this.fetchPartialBalance('used', params);
     }
 
-    async fetchTotalBalance (params = {}) {
-        return await this.fetchPartialBalance ('total', params);
+    async fetchTotalBalance(params = {}) {
+        return await this.fetchPartialBalance('total', params);
     }
 
-    async fetchStatus (params = {}) {
+    async fetchStatus(params = {}) {
         if (this.has['fetchTime']) {
-            const time = await this.fetchTime (params);
-            this.status = this.extend (this.status, {
+            const time = await this.fetchTime(params);
+            this.status = this.extend(this.status, {
                 'updated': time,
             });
         }
         return this.status;
     }
 
-    async fetchFundingFee (code, params = {}) {
-        const warnOnFetchFundingFee = this.safeValue (this.options, 'warnOnFetchFundingFee', true);
+    async fetchFundingFee(code, params = {}) {
+        const warnOnFetchFundingFee = this.safeValue(this.options, 'warnOnFetchFundingFee', true);
         if (warnOnFetchFundingFee) {
-            throw new NotSupported (this.id + ' fetchFundingFee() method is deprecated, it will be removed in July 2022, please, use fetchTransactionFee() or set exchange.options["warnOnFetchFundingFee"] = false to suppress this warning');
+            throw new NotSupported(this.id + ' fetchFundingFee() method is deprecated, it will be removed in July 2022, please, use fetchTransactionFee() or set exchange.options["warnOnFetchFundingFee"] = false to suppress this warning');
         }
-        return await this.fetchTransactionFee (code, params);
+        return await this.fetchTransactionFee(code, params);
     }
 
-    async fetchFundingFees (codes = undefined, params = {}) {
-        const warnOnFetchFundingFees = this.safeValue (this.options, 'warnOnFetchFundingFees', true);
+    async fetchFundingFees(codes = undefined, params = {}) {
+        const warnOnFetchFundingFees = this.safeValue(this.options, 'warnOnFetchFundingFees', true);
         if (warnOnFetchFundingFees) {
-            throw new NotSupported (this.id + ' fetchFundingFees() method is deprecated, it will be removed in July 2022. Please, use fetchTransactionFees() or set exchange.options["warnOnFetchFundingFees"] = false to suppress this warning');
+            throw new NotSupported(this.id + ' fetchFundingFees() method is deprecated, it will be removed in July 2022. Please, use fetchTransactionFees() or set exchange.options["warnOnFetchFundingFees"] = false to suppress this warning');
         }
-        return await this.fetchTransactionFees (codes, params);
+        return await this.fetchTransactionFees(codes, params);
     }
 
-    async fetchTransactionFee (code, params = {}) {
+    async fetchTransactionFee(code, params = {}) {
         if (!this.has['fetchTransactionFees']) {
-            throw new NotSupported (this.id + ' fetchTransactionFee() is not supported yet');
+            throw new NotSupported(this.id + ' fetchTransactionFee() is not supported yet');
         }
-        return await this.fetchTransactionFees ([ code ], params);
+        return await this.fetchTransactionFees([code], params);
     }
 
-    async fetchTransactionFees (codes = undefined, params = {}) {
-        throw new NotSupported (this.id + ' fetchTransactionFees() is not supported yet');
+    async fetchTransactionFees(codes = undefined, params = {}) {
+        throw new NotSupported(this.id + ' fetchTransactionFees() is not supported yet');
     }
 
-    async fetchDepositWithdrawFee (code, params = {}) {
+    async fetchDepositWithdrawFee(code, params = {}) {
         if (!this.has['fetchDepositWithdrawFees']) {
-            throw new NotSupported (this.id + ' fetchDepositWithdrawFee() is not supported yet');
+            throw new NotSupported(this.id + ' fetchDepositWithdrawFee() is not supported yet');
         }
-        const fees = await this.fetchDepositWithdrawFees ([ code ], params);
-        return this.safeValue (fees, code);
+        const fees = await this.fetchDepositWithdrawFees([code], params);
+        return this.safeValue(fees, code);
     }
 
-    getSupportedMapping (key, mapping = {}) {
+    getSupportedMapping(key, mapping = {}) {
         if (key in mapping) {
             return mapping[key];
         } else {
-            throw new NotSupported (this.id + ' ' + key + ' does not have a value in mapping');
+            throw new NotSupported(this.id + ' ' + key + ' does not have a value in mapping');
         }
     }
 
-    async fetchBorrowRate (code, params = {}) {
-        await this.loadMarkets ();
+    async fetchBorrowRate(code, params = {}) {
+        await this.loadMarkets();
         if (!this.has['fetchBorrowRates']) {
-            throw new NotSupported (this.id + ' fetchBorrowRate() is not supported yet');
+            throw new NotSupported(this.id + ' fetchBorrowRate() is not supported yet');
         }
-        const borrowRates = await this.fetchBorrowRates (params);
-        const rate = this.safeValue (borrowRates, code);
+        const borrowRates = await this.fetchBorrowRates(params);
+        const rate = this.safeValue(borrowRates, code);
         if (rate === undefined) {
-            throw new ExchangeError (this.id + ' fetchBorrowRate() could not find the borrow rate for currency code ' + code);
+            throw new ExchangeError(this.id + ' fetchBorrowRate() could not find the borrow rate for currency code ' + code);
         }
         return rate;
     }
 
-    handleOptionAndParams (params, methodName, optionName, defaultValue = undefined) {
+    handleOptionAndParams(params, methodName, optionName, defaultValue = undefined) {
         // This method can be used to obtain method specific properties, i.e: this.handleOptionAndParams (params, 'fetchPosition', 'marginMode', 'isolated')
-        const defaultOptionName = 'default' + this.capitalize (optionName); // we also need to check the 'defaultXyzWhatever'
+        const defaultOptionName = 'default' + this.capitalize(optionName); // we also need to check the 'defaultXyzWhatever'
         // check if params contain the key
-        let value = this.safeValue2 (params, optionName, defaultOptionName);
+        let value = this.safeValue2(params, optionName, defaultOptionName);
         if (value !== undefined) {
-            params = this.omit (params, [ optionName, defaultOptionName ]);
+            params = this.omit(params, [optionName, defaultOptionName]);
         } else {
             // check if exchange has properties for this method
-            const exchangeWideMethodOptions = this.safeValue (this.options, methodName);
+            const exchangeWideMethodOptions = this.safeValue(this.options, methodName);
             if (exchangeWideMethodOptions !== undefined) {
                 // check if the option is defined in this method's props
-                value = this.safeValue2 (exchangeWideMethodOptions, optionName, defaultOptionName);
+                value = this.safeValue2(exchangeWideMethodOptions, optionName, defaultOptionName);
             }
             if (value === undefined) {
                 // if it's still undefined, check if global exchange-wide option exists
-                value = this.safeValue2 (this.options, optionName, defaultOptionName);
+                value = this.safeValue2(this.options, optionName, defaultOptionName);
             }
             // if it's still undefined, use the default value
             value = (value !== undefined) ? value : defaultValue;
         }
-        return [ value, params ];
+        return [value, params];
     }
 
     handleOption (methodName, optionName, defaultValue = undefined) {
@@ -2361,31 +2361,31 @@ module.exports = class Exchange {
         return result;
     }
 
-    handleMarketTypeAndParams (methodName, market = undefined, params = {}) {
-        const defaultType = this.safeString2 (this.options, 'defaultType', 'type', 'spot');
-        const methodOptions = this.safeValue (this.options, methodName);
+    handleMarketTypeAndParams(methodName, market = undefined, params = {}) {
+        const defaultType = this.safeString2(this.options, 'defaultType', 'type', 'spot');
+        const methodOptions = this.safeValue(this.options, methodName);
         let methodType = defaultType;
         if (methodOptions !== undefined) {
             if (typeof methodOptions === 'string') {
                 methodType = methodOptions;
             } else {
-                methodType = this.safeString2 (methodOptions, 'defaultType', 'type', methodType);
+                methodType = this.safeString2(methodOptions, 'defaultType', 'type', methodType);
             }
         }
         const marketType = (market === undefined) ? methodType : market['type'];
-        const type = this.safeString2 (params, 'defaultType', 'type', marketType);
-        params = this.omit (params, [ 'defaultType', 'type' ]);
-        return [ type, params ];
+        const type = this.safeString2(params, 'defaultType', 'type', marketType);
+        params = this.omit(params, ['defaultType', 'type']);
+        return [type, params];
     }
 
-    handleSubTypeAndParams (methodName, market = undefined, params = {}, defaultValue = undefined) {
+    handleSubTypeAndParams(methodName, market = undefined, params = {}, defaultValue = undefined) {
         let subType = undefined;
         // if set in params, it takes precedence
-        const subTypeInParams = this.safeString2 (params, 'subType', 'defaultSubType');
+        const subTypeInParams = this.safeString2(params, 'subType', 'defaultSubType');
         // avoid omitting if it's not present
         if (subTypeInParams !== undefined) {
             subType = subTypeInParams;
-            params = this.omit (params, [ 'subType', 'defaultSubType' ]);
+            params = this.omit(params, ['subType', 'defaultSubType']);
         } else {
             // at first, check from market object
             if (market !== undefined) {
@@ -2397,43 +2397,43 @@ module.exports = class Exchange {
             }
             // if it was not defined in market object
             if (subType === undefined) {
-                const values = this.handleOptionAndParams (undefined, methodName, 'subType', defaultValue); // no need to re-test params here
+                const values = this.handleOptionAndParams(undefined, methodName, 'subType', defaultValue); // no need to re-test params here
                 subType = values[0];
             }
         }
-        return [ subType, params ];
+        return [subType, params];
     }
 
-    handleMarginModeAndParams (methodName, params = {}, defaultValue = undefined) {
+    handleMarginModeAndParams(methodName, params = {}, defaultValue = undefined) {
         /**
          * @ignore
          * @method
          * @param {object} params extra parameters specific to the exchange api endpoint
          * @returns {[string|undefined, object]} the marginMode in lowercase as specified by params["marginMode"], params["defaultMarginMode"] this.options["marginMode"] or this.options["defaultMarginMode"]
          */
-        return this.handleOptionAndParams (params, methodName, 'marginMode', defaultValue);
+        return this.handleOptionAndParams(params, methodName, 'marginMode', defaultValue);
     }
 
-    throwExactlyMatchedException (exact, string, message) {
+    throwExactlyMatchedException(exact, string, message) {
         if (string in exact) {
-            throw new exact[string] (message);
+            throw new exact[string](message);
         }
     }
 
-    throwBroadlyMatchedException (broad, string, message) {
-        const broadKey = this.findBroadlyMatchedKey (broad, string);
+    throwBroadlyMatchedException(broad, string, message) {
+        const broadKey = this.findBroadlyMatchedKey(broad, string);
         if (broadKey !== undefined) {
-            throw new broad[broadKey] (message);
+            throw new broad[broadKey](message);
         }
     }
 
-    findBroadlyMatchedKey (broad, string) {
+    findBroadlyMatchedKey(broad, string) {
         // a helper for matching error strings exactly vs broadly
-        const keys = Object.keys (broad);
+        const keys = Object.keys(broad);
         for (let i = 0; i < keys.length; i++) {
             const key = keys[i];
             if (string !== undefined) { // #issues/12698
-                if (string.indexOf (key) >= 0) {
+                if (string.indexOf(key) >= 0) {
                     return key;
                 }
             }
@@ -2441,101 +2441,101 @@ module.exports = class Exchange {
         return undefined;
     }
 
-    handleErrors (statusCode, statusText, url, method, responseHeaders, responseBody, response, requestHeaders, requestBody) {
+    handleErrors(statusCode, statusText, url, method, responseHeaders, responseBody, response, requestHeaders, requestBody) {
         // it is a stub method that must be overrided in the derived exchange classes
         // throw new NotSupported (this.id + ' handleErrors() not implemented yet');
     }
 
-    calculateRateLimiterCost (api, method, path, params, config = {}, context = {}) {
-        return this.safeValue (config, 'cost', 1);
+    calculateRateLimiterCost(api, method, path, params, config = {}, context = {}) {
+        return this.safeValue(config, 'cost', 1);
     }
 
-    async fetchTicker (symbol, params = {}) {
+    async fetchTicker(symbol, params = {}) {
         if (this.has['fetchTickers']) {
-            const tickers = await this.fetchTickers ([ symbol ], params);
-            const ticker = this.safeValue (tickers, symbol);
+            const tickers = await this.fetchTickers([symbol], params);
+            const ticker = this.safeValue(tickers, symbol);
             if (ticker === undefined) {
-                throw new NullResponse (this.id + ' fetchTickers() could not find a ticker for ' + symbol);
+                throw new NullResponse(this.id + ' fetchTickers() could not find a ticker for ' + symbol);
             } else {
                 return ticker;
             }
         } else {
-            throw new NotSupported (this.id + ' fetchTicker() is not supported yet');
+            throw new NotSupported(this.id + ' fetchTicker() is not supported yet');
         }
     }
 
-    async fetchTickers (symbols = undefined, params = {}) {
-        throw new NotSupported (this.id + ' fetchTickers() is not supported yet');
+    async fetchTickers(symbols = undefined, params = {}) {
+        throw new NotSupported(this.id + ' fetchTickers() is not supported yet');
     }
 
-    async fetchOrder (id, symbol = undefined, params = {}) {
-        throw new NotSupported (this.id + ' fetchOrder() is not supported yet');
+    async fetchOrder(id, symbol = undefined, params = {}) {
+        throw new NotSupported(this.id + ' fetchOrder() is not supported yet');
     }
 
-    async fetchOrderStatus (id, symbol = undefined, params = {}) {
-        const order = await this.fetchOrder (id, symbol, params);
+    async fetchOrderStatus(id, symbol = undefined, params = {}) {
+        const order = await this.fetchOrder(id, symbol, params);
         return order['status'];
     }
 
-    async fetchUnifiedOrder (order, params = {}) {
-        return await this.fetchOrder (this.safeValue (order, 'id'), this.safeValue (order, 'symbol'), params);
+    async fetchUnifiedOrder(order, params = {}) {
+        return await this.fetchOrder(this.safeValue(order, 'id'), this.safeValue(order, 'symbol'), params);
     }
 
-    async createOrder (symbol, type, side, amount, price = undefined, params = {}) {
-        throw new NotSupported (this.id + ' createOrder() is not supported yet');
+    async createOrder(symbol, type, side, amount, price = undefined, params = {}) {
+        throw new NotSupported(this.id + ' createOrder() is not supported yet');
     }
 
-    async cancelOrder (id, symbol = undefined, params = {}) {
-        throw new NotSupported (this.id + ' cancelOrder() is not supported yet');
+    async cancelOrder(id, symbol = undefined, params = {}) {
+        throw new NotSupported(this.id + ' cancelOrder() is not supported yet');
     }
 
-    async cancelUnifiedOrder (order, params = {}) {
-        return this.cancelOrder (this.safeValue (order, 'id'), this.safeValue (order, 'symbol'), params);
+    async cancelUnifiedOrder(order, params = {}) {
+        return this.cancelOrder(this.safeValue(order, 'id'), this.safeValue(order, 'symbol'), params);
     }
 
-    async fetchOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
-        throw new NotSupported (this.id + ' fetchOrders() is not supported yet');
+    async fetchOrders(symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        throw new NotSupported(this.id + ' fetchOrders() is not supported yet');
     }
 
-    async fetchOpenOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
-        throw new NotSupported (this.id + ' fetchOpenOrders() is not supported yet');
+    async fetchOpenOrders(symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        throw new NotSupported(this.id + ' fetchOpenOrders() is not supported yet');
     }
 
-    async fetchClosedOrders (symbol = undefined, since = undefined, limit = undefined, params = {}) {
-        throw new NotSupported (this.id + ' fetchClosedOrders() is not supported yet');
+    async fetchClosedOrders(symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        throw new NotSupported(this.id + ' fetchClosedOrders() is not supported yet');
     }
 
-    async fetchMyTrades (symbol = undefined, since = undefined, limit = undefined, params = {}) {
-        throw new NotSupported (this.id + ' fetchMyTrades() is not supported yet');
+    async fetchMyTrades(symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        throw new NotSupported(this.id + ' fetchMyTrades() is not supported yet');
     }
 
-    async fetchTransactions (symbol = undefined, since = undefined, limit = undefined, params = {}) {
-        throw new NotSupported (this.id + ' fetchTransactions() is not supported yet');
+    async fetchTransactions(symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        throw new NotSupported(this.id + ' fetchTransactions() is not supported yet');
     }
 
-    async fetchDeposits (symbol = undefined, since = undefined, limit = undefined, params = {}) {
-        throw new NotSupported (this.id + ' fetchDeposits() is not supported yet');
+    async fetchDeposits(symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        throw new NotSupported(this.id + ' fetchDeposits() is not supported yet');
     }
 
-    async fetchWithdrawals (symbol = undefined, since = undefined, limit = undefined, params = {}) {
-        throw new NotSupported (this.id + ' fetchWithdrawals() is not supported yet');
+    async fetchWithdrawals(symbol = undefined, since = undefined, limit = undefined, params = {}) {
+        throw new NotSupported(this.id + ' fetchWithdrawals() is not supported yet');
     }
 
-    async fetchDepositAddress (code, params = {}) {
+    async fetchDepositAddress(code, params = {}) {
         if (this.has['fetchDepositAddresses']) {
-            const depositAddresses = await this.fetchDepositAddresses ([ code ], params);
-            const depositAddress = this.safeValue (depositAddresses, code);
+            const depositAddresses = await this.fetchDepositAddresses([code], params);
+            const depositAddress = this.safeValue(depositAddresses, code);
             if (depositAddress === undefined) {
-                throw new InvalidAddress (this.id + ' fetchDepositAddress() could not find a deposit address for ' + code + ', make sure you have created a corresponding deposit address in your wallet on the exchange website');
+                throw new InvalidAddress(this.id + ' fetchDepositAddress() could not find a deposit address for ' + code + ', make sure you have created a corresponding deposit address in your wallet on the exchange website');
             } else {
                 return depositAddress;
             }
         } else {
-            throw new NotSupported (this.id + ' fetchDepositAddress() is not supported yet');
+            throw new NotSupported(this.id + ' fetchDepositAddress() is not supported yet');
         }
     }
 
-    account () {
+    account() {
         return {
             'free': undefined,
             'used': undefined,
@@ -2543,16 +2543,16 @@ module.exports = class Exchange {
         };
     }
 
-    commonCurrencyCode (currency) {
+    commonCurrencyCode(currency) {
         if (!this.substituteCommonCurrencyCodes) {
             return currency;
         }
-        return this.safeString (this.commonCurrencies, currency, currency);
+        return this.safeString(this.commonCurrencies, currency, currency);
     }
 
-    currency (code) {
+    currency(code) {
         if (this.currencies === undefined) {
-            throw new ExchangeError (this.id + ' currencies not loaded');
+            throw new ExchangeError(this.id + ' currencies not loaded');
         }
         if (typeof code === 'string') {
             if (code in this.currencies) {
@@ -2561,19 +2561,19 @@ module.exports = class Exchange {
                 return this.currencies_by_id[code];
             }
         }
-        throw new ExchangeError (this.id + ' does not have currency code ' + code);
+        throw new ExchangeError(this.id + ' does not have currency code ' + code);
     }
 
-    market (symbol) {
+    market(symbol) {
         if (this.markets === undefined) {
-            throw new ExchangeError (this.id + ' markets not loaded');
+            throw new ExchangeError(this.id + ' markets not loaded');
         }
         if (typeof symbol === 'string') {
             if (symbol in this.markets) {
                 return this.markets[symbol];
             } else if (symbol in this.markets_by_id) {
                 const markets = this.markets_by_id[symbol];
-                const defaultType = this.safeString2 (this.options, 'defaultType', 'defaultSubType', 'spot');
+                const defaultType = this.safeString2(this.options, 'defaultType', 'defaultSubType', 'spot');
                 for (let i = 0; i < markets.length; i++) {
                     const market = markets[i];
                     if (market[defaultType]) {
@@ -2583,188 +2583,188 @@ module.exports = class Exchange {
                 return markets[0];
             }
         }
-        throw new BadSymbol (this.id + ' does not have market symbol ' + symbol);
+        throw new BadSymbol(this.id + ' does not have market symbol ' + symbol);
     }
 
-    handleWithdrawTagAndParams (tag, params) {
+    handleWithdrawTagAndParams(tag, params) {
         if (typeof tag === 'object') {
-            params = this.extend (tag, params);
+            params = this.extend(tag, params);
             tag = undefined;
         }
         if (tag === undefined) {
-            tag = this.safeString (params, 'tag');
+            tag = this.safeString(params, 'tag');
             if (tag !== undefined) {
-                params = this.omit (params, 'tag');
+                params = this.omit(params, 'tag');
             }
         }
-        return [ tag, params ];
+        return [tag, params];
     }
 
-    async createLimitOrder (symbol, side, amount, price, params = {}) {
-        return await this.createOrder (symbol, 'limit', side, amount, price, params);
+    async createLimitOrder(symbol, side, amount, price, params = {}) {
+        return await this.createOrder(symbol, 'limit', side, amount, price, params);
     }
 
-    async createMarketOrder (symbol, side, amount, price = undefined, params = {}) {
-        return await this.createOrder (symbol, 'market', side, amount, price, params);
+    async createMarketOrder(symbol, side, amount, price = undefined, params = {}) {
+        return await this.createOrder(symbol, 'market', side, amount, price, params);
     }
 
-    async createLimitBuyOrder (symbol, amount, price, params = {}) {
-        return await this.createOrder (symbol, 'limit', 'buy', amount, price, params);
+    async createLimitBuyOrder(symbol, amount, price, params = {}) {
+        return await this.createOrder(symbol, 'limit', 'buy', amount, price, params);
     }
 
-    async createLimitSellOrder (symbol, amount, price, params = {}) {
-        return await this.createOrder (symbol, 'limit', 'sell', amount, price, params);
+    async createLimitSellOrder(symbol, amount, price, params = {}) {
+        return await this.createOrder(symbol, 'limit', 'sell', amount, price, params);
     }
 
-    async createMarketBuyOrder (symbol, amount, params = {}) {
-        return await this.createOrder (symbol, 'market', 'buy', amount, undefined, params);
+    async createMarketBuyOrder(symbol, amount, params = {}) {
+        return await this.createOrder(symbol, 'market', 'buy', amount, undefined, params);
     }
 
-    async createMarketSellOrder (symbol, amount, params = {}) {
-        return await this.createOrder (symbol, 'market', 'sell', amount, undefined, params);
+    async createMarketSellOrder(symbol, amount, params = {}) {
+        return await this.createOrder(symbol, 'market', 'sell', amount, undefined, params);
     }
 
-    costToPrecision (symbol, cost) {
-        const market = this.market (symbol);
-        return this.decimalToPrecision (cost, TRUNCATE, market['precision']['price'], this.precisionMode, this.paddingMode);
+    costToPrecision(symbol, cost) {
+        const market = this.market(symbol);
+        return this.decimalToPrecision(cost, TRUNCATE, market['precision']['price'], this.precisionMode, this.paddingMode);
     }
 
-    priceToPrecision (symbol, price) {
-        const market = this.market (symbol);
-        const result = this.decimalToPrecision (price, ROUND, market['precision']['price'], this.precisionMode, this.paddingMode);
+    priceToPrecision(symbol, price) {
+        const market = this.market(symbol);
+        const result = this.decimalToPrecision(price, ROUND, market['precision']['price'], this.precisionMode, this.paddingMode);
         if (result === '0') {
-            throw new ArgumentsRequired (this.id + ' price of ' + market['symbol'] + ' must be greater than minimum price precision of ' + this.numberToString (market['precision']['price']));
+            throw new ArgumentsRequired(this.id + ' price of ' + market['symbol'] + ' must be greater than minimum price precision of ' + this.numberToString(market['precision']['price']));
         }
         return result;
     }
 
-    amountToPrecision (symbol, amount) {
-        const market = this.market (symbol);
-        const result = this.decimalToPrecision (amount, TRUNCATE, market['precision']['amount'], this.precisionMode, this.paddingMode);
+    amountToPrecision(symbol, amount) {
+        const market = this.market(symbol);
+        const result = this.decimalToPrecision(amount, TRUNCATE, market['precision']['amount'], this.precisionMode, this.paddingMode);
         if (result === '0') {
-            throw new ArgumentsRequired (this.id + ' amount of ' + market['symbol'] + ' must be greater than minimum amount precision of ' + this.numberToString (market['precision']['amount']));
+            throw new ArgumentsRequired(this.id + ' amount of ' + market['symbol'] + ' must be greater than minimum amount precision of ' + this.numberToString(market['precision']['amount']));
         }
         return result;
     }
 
-    feeToPrecision (symbol, fee) {
-        const market = this.market (symbol);
-        return this.decimalToPrecision (fee, ROUND, market['precision']['price'], this.precisionMode, this.paddingMode);
+    feeToPrecision(symbol, fee) {
+        const market = this.market(symbol);
+        return this.decimalToPrecision(fee, ROUND, market['precision']['price'], this.precisionMode, this.paddingMode);
     }
 
-    currencyToPrecision (code, fee, networkCode = undefined) {
+    currencyToPrecision(code, fee, networkCode = undefined) {
         const currency = this.currencies[code];
-        let precision = this.safeValue (currency, 'precision');
+        let precision = this.safeValue(currency, 'precision');
         if (networkCode !== undefined) {
-            const networks = this.safeValue (currency, 'networks', {});
-            const networkItem = this.safeValue (networks, networkCode, {});
-            precision = this.safeValue (networkItem, 'precision', precision);
+            const networks = this.safeValue(currency, 'networks', {});
+            const networkItem = this.safeValue(networks, networkCode, {});
+            precision = this.safeValue(networkItem, 'precision', precision);
         }
         if (precision === undefined) {
             return fee;
         } else {
-            return this.decimalToPrecision (fee, ROUND, precision, this.precisionMode, this.paddingMode);
+            return this.decimalToPrecision(fee, ROUND, precision, this.precisionMode, this.paddingMode);
         }
     }
 
-    safeNumber (object, key, d = undefined) {
-        const value = this.safeString (object, key);
-        return this.parseNumber (value, d);
+    safeNumber(object, key, d = undefined) {
+        const value = this.safeString(object, key);
+        return this.parseNumber(value, d);
     }
 
-    safeNumberN (object, arr, d = undefined) {
-        const value = this.safeStringN (object, arr);
-        return this.parseNumber (value, d);
+    safeNumberN(object, arr, d = undefined) {
+        const value = this.safeStringN(object, arr);
+        return this.parseNumber(value, d);
     }
 
-    parsePrecision (precision) {
+    parsePrecision(precision) {
         if (precision === undefined) {
             return undefined;
         }
-        return '1e' + Precise.stringNeg (precision);
+        return '1e' + Precise.stringNeg(precision);
     }
 
-    async loadTimeDifference (params = {}) {
-        const serverTime = await this.fetchTime (params);
-        const after = this.milliseconds ();
+    async loadTimeDifference(params = {}) {
+        const serverTime = await this.fetchTime(params);
+        const after = this.milliseconds();
         this.options['timeDifference'] = after - serverTime;
         return this.options['timeDifference'];
     }
 
-    implodeHostname (url) {
-        return this.implodeParams (url, { 'hostname': this.hostname });
+    implodeHostname(url) {
+        return this.implodeParams(url, { 'hostname': this.hostname });
     }
 
-    async fetchMarketLeverageTiers (symbol, params = {}) {
+    async fetchMarketLeverageTiers(symbol, params = {}) {
         if (this.has['fetchLeverageTiers']) {
-            const market = await this.market (symbol);
+            const market = await this.market(symbol);
             if (!market['contract']) {
-                throw new BadSymbol (this.id + ' fetchMarketLeverageTiers() supports contract markets only');
+                throw new BadSymbol(this.id + ' fetchMarketLeverageTiers() supports contract markets only');
             }
-            const tiers = await this.fetchLeverageTiers ([ symbol ]);
-            return this.safeValue (tiers, symbol);
+            const tiers = await this.fetchLeverageTiers([symbol]);
+            return this.safeValue(tiers, symbol);
         } else {
-            throw new NotSupported (this.id + ' fetchMarketLeverageTiers() is not supported yet');
+            throw new NotSupported(this.id + ' fetchMarketLeverageTiers() is not supported yet');
         }
     }
 
-    async createPostOnlyOrder (symbol, type, side, amount, price, params = {}) {
+    async createPostOnlyOrder(symbol, type, side, amount, price, params = {}) {
         if (!this.has['createPostOnlyOrder']) {
-            throw new NotSupported (this.id + 'createPostOnlyOrder() is not supported yet');
+            throw new NotSupported(this.id + 'createPostOnlyOrder() is not supported yet');
         }
-        const query = this.extend (params, { 'postOnly': true });
-        return await this.createOrder (symbol, type, side, amount, price, query);
+        const query = this.extend(params, { 'postOnly': true });
+        return await this.createOrder(symbol, type, side, amount, price, query);
     }
 
-    async createReduceOnlyOrder (symbol, type, side, amount, price, params = {}) {
+    async createReduceOnlyOrder(symbol, type, side, amount, price, params = {}) {
         if (!this.has['createReduceOnlyOrder']) {
-            throw new NotSupported (this.id + 'createReduceOnlyOrder() is not supported yet');
+            throw new NotSupported(this.id + 'createReduceOnlyOrder() is not supported yet');
         }
-        const query = this.extend (params, { 'reduceOnly': true });
-        return await this.createOrder (symbol, type, side, amount, price, query);
+        const query = this.extend(params, { 'reduceOnly': true });
+        return await this.createOrder(symbol, type, side, amount, price, query);
     }
 
-    async createStopOrder (symbol, type, side, amount, price = undefined, stopPrice = undefined, params = {}) {
+    async createStopOrder(symbol, type, side, amount, price = undefined, stopPrice = undefined, params = {}) {
         if (!this.has['createStopOrder']) {
-            throw new NotSupported (this.id + ' createStopOrder() is not supported yet');
+            throw new NotSupported(this.id + ' createStopOrder() is not supported yet');
         }
         if (stopPrice === undefined) {
-            throw new ArgumentsRequired (this.id + ' create_stop_order() requires a stopPrice argument');
+            throw new ArgumentsRequired(this.id + ' create_stop_order() requires a stopPrice argument');
         }
-        const query = this.extend (params, { 'stopPrice': stopPrice });
-        return await this.createOrder (symbol, type, side, amount, price, query);
+        const query = this.extend(params, { 'stopPrice': stopPrice });
+        return await this.createOrder(symbol, type, side, amount, price, query);
     }
 
-    async createStopLimitOrder (symbol, side, amount, price, stopPrice, params = {}) {
+    async createStopLimitOrder(symbol, side, amount, price, stopPrice, params = {}) {
         if (!this.has['createStopLimitOrder']) {
-            throw new NotSupported (this.id + ' createStopLimitOrder() is not supported yet');
+            throw new NotSupported(this.id + ' createStopLimitOrder() is not supported yet');
         }
-        const query = this.extend (params, { 'stopPrice': stopPrice });
-        return await this.createOrder (symbol, 'limit', side, amount, price, query);
+        const query = this.extend(params, { 'stopPrice': stopPrice });
+        return await this.createOrder(symbol, 'limit', side, amount, price, query);
     }
 
-    async createStopMarketOrder (symbol, side, amount, stopPrice, params = {}) {
+    async createStopMarketOrder(symbol, side, amount, stopPrice, params = {}) {
         if (!this.has['createStopMarketOrder']) {
-            throw new NotSupported (this.id + ' createStopMarketOrder() is not supported yet');
+            throw new NotSupported(this.id + ' createStopMarketOrder() is not supported yet');
         }
-        const query = this.extend (params, { 'stopPrice': stopPrice });
-        return await this.createOrder (symbol, 'market', side, amount, undefined, query);
+        const query = this.extend(params, { 'stopPrice': stopPrice });
+        return await this.createOrder(symbol, 'market', side, amount, undefined, query);
     }
 
-    safeCurrencyCode (currencyId, currency = undefined) {
-        currency = this.safeCurrency (currencyId, currency);
+    safeCurrencyCode(currencyId, currency = undefined) {
+        currency = this.safeCurrency(currencyId, currency);
         return currency['code'];
     }
 
-    filterBySymbolSinceLimit (array, symbol = undefined, since = undefined, limit = undefined, tail = false) {
-        return this.filterByValueSinceLimit (array, 'symbol', symbol, since, limit, 'timestamp', tail);
+    filterBySymbolSinceLimit(array, symbol = undefined, since = undefined, limit = undefined, tail = false) {
+        return this.filterByValueSinceLimit(array, 'symbol', symbol, since, limit, 'timestamp', tail);
     }
 
-    filterByCurrencySinceLimit (array, code = undefined, since = undefined, limit = undefined, tail = false) {
-        return this.filterByValueSinceLimit (array, 'currency', code, since, limit, 'timestamp', tail);
+    filterByCurrencySinceLimit(array, code = undefined, since = undefined, limit = undefined, tail = false) {
+        return this.filterByValueSinceLimit(array, 'currency', code, since, limit, 'timestamp', tail);
     }
 
-    parseTickers (tickers, symbols = undefined, params = {}) {
+    parseTickers(tickers, symbols = undefined, params = {}) {
         //
         // the value of tickers is either a dict or a list
         //
@@ -2787,84 +2787,84 @@ module.exports = class Exchange {
         //     ]
         //
         const results = [];
-        if (Array.isArray (tickers)) {
+        if (Array.isArray(tickers)) {
             for (let i = 0; i < tickers.length; i++) {
-                const ticker = this.extend (this.parseTicker (tickers[i]), params);
-                results.push (ticker);
+                const ticker = this.extend(this.parseTicker(tickers[i]), params);
+                results.push(ticker);
             }
         } else {
-            const marketIds = Object.keys (tickers);
+            const marketIds = Object.keys(tickers);
             for (let i = 0; i < marketIds.length; i++) {
                 const marketId = marketIds[i];
-                const market = this.safeMarket (marketId);
-                const ticker = this.extend (this.parseTicker (tickers[marketId], market), params);
-                results.push (ticker);
+                const market = this.safeMarket(marketId);
+                const ticker = this.extend(this.parseTicker(tickers[marketId], market), params);
+                results.push(ticker);
             }
         }
-        symbols = this.marketSymbols (symbols);
-        return this.filterByArray (results, 'symbol', symbols);
+        symbols = this.marketSymbols(symbols);
+        return this.filterByArray(results, 'symbol', symbols);
     }
 
-    parseDepositAddresses (addresses, codes = undefined, indexed = true, params = {}) {
+    parseDepositAddresses(addresses, codes = undefined, indexed = true, params = {}) {
         let result = [];
         for (let i = 0; i < addresses.length; i++) {
-            const address = this.extend (this.parseDepositAddress (addresses[i]), params);
-            result.push (address);
+            const address = this.extend(this.parseDepositAddress(addresses[i]), params);
+            result.push(address);
         }
         if (codes !== undefined) {
-            result = this.filterByArray (result, 'currency', codes, false);
+            result = this.filterByArray(result, 'currency', codes, false);
         }
-        result = indexed ? this.indexBy (result, 'currency') : result;
+        result = indexed ? this.indexBy(result, 'currency') : result;
         return result;
     }
 
-    parseBorrowInterests (response, market = undefined) {
+    parseBorrowInterests(response, market = undefined) {
         const interests = [];
         for (let i = 0; i < response.length; i++) {
             const row = response[i];
-            interests.push (this.parseBorrowInterest (row, market));
+            interests.push(this.parseBorrowInterest(row, market));
         }
         return interests;
     }
 
-    parseFundingRateHistories (response, market = undefined, since = undefined, limit = undefined) {
+    parseFundingRateHistories(response, market = undefined, since = undefined, limit = undefined) {
         const rates = [];
         for (let i = 0; i < response.length; i++) {
             const entry = response[i];
-            rates.push (this.parseFundingRateHistory (entry, market));
+            rates.push(this.parseFundingRateHistory(entry, market));
         }
-        const sorted = this.sortBy (rates, 'timestamp');
+        const sorted = this.sortBy(rates, 'timestamp');
         const symbol = (market === undefined) ? undefined : market['symbol'];
-        return this.filterBySymbolSinceLimit (sorted, symbol, since, limit);
+        return this.filterBySymbolSinceLimit(sorted, symbol, since, limit);
     }
 
-    safeSymbol (marketId, market = undefined, delimiter = undefined, marketType = undefined) {
-        market = this.safeMarket (marketId, market, delimiter, marketType);
+    safeSymbol(marketId, market = undefined, delimiter = undefined, marketType = undefined) {
+        market = this.safeMarket(marketId, market, delimiter, marketType);
         return market['symbol'];
     }
 
-    parseFundingRate (contract, market = undefined) {
-        throw new NotSupported (this.id + ' parseFundingRate() is not supported yet');
+    parseFundingRate(contract, market = undefined) {
+        throw new NotSupported(this.id + ' parseFundingRate() is not supported yet');
     }
 
-    parseFundingRates (response, market = undefined) {
+    parseFundingRates(response, market = undefined) {
         const result = {};
         for (let i = 0; i < response.length; i++) {
-            const parsed = this.parseFundingRate (response[i], market);
+            const parsed = this.parseFundingRate(response[i], market);
             result[parsed['symbol']] = parsed;
         }
         return result;
     }
 
-    isTriggerOrder (params) {
-        const isTrigger = this.safeValue2 (params, 'trigger', 'stop');
+    isTriggerOrder(params) {
+        const isTrigger = this.safeValue2(params, 'trigger', 'stop');
         if (isTrigger) {
-            params = this.omit (params, [ 'trigger', 'stop' ]);
+            params = this.omit(params, ['trigger', 'stop']);
         }
-        return [ isTrigger, params ];
+        return [isTrigger, params];
     }
 
-    isPostOnly (isMarketOrder, exchangeSpecificParam, params = {}) {
+    isPostOnly(isMarketOrder, exchangeSpecificParam, params = {}) {
         /**
          * @ignore
          * @method
@@ -2873,8 +2873,8 @@ module.exports = class Exchange {
          * @param {object} params exchange specific params
          * @returns {boolean} true if a post only order, false otherwise
          */
-        const timeInForce = this.safeStringUpper (params, 'timeInForce');
-        let postOnly = this.safeValue2 (params, 'postOnly', 'post_only', false);
+        const timeInForce = this.safeStringUpper(params, 'timeInForce');
+        let postOnly = this.safeValue2(params, 'postOnly', 'post_only', false);
         // we assume timeInForce is uppercase from safeStringUpper (params, 'timeInForce')
         const ioc = timeInForce === 'IOC';
         const fok = timeInForce === 'FOK';
@@ -2882,9 +2882,9 @@ module.exports = class Exchange {
         postOnly = postOnly || timeInForcePostOnly || exchangeSpecificParam;
         if (postOnly) {
             if (ioc || fok) {
-                throw new InvalidOrder (this.id + ' postOnly orders cannot have timeInForce equal to ' + timeInForce);
+                throw new InvalidOrder(this.id + ' postOnly orders cannot have timeInForce equal to ' + timeInForce);
             } else if (isMarketOrder) {
-                throw new InvalidOrder (this.id + ' market orders cannot be postOnly');
+                throw new InvalidOrder(this.id + ' market orders cannot be postOnly');
             } else {
                 return true;
             }
@@ -2893,53 +2893,53 @@ module.exports = class Exchange {
         }
     }
 
-    async fetchTradingFees (params = {}) {
-        throw new NotSupported (this.id + ' fetchTradingFees() is not supported yet');
+    async fetchTradingFees(params = {}) {
+        throw new NotSupported(this.id + ' fetchTradingFees() is not supported yet');
     }
 
-    async fetchTradingFee (symbol, params = {}) {
+    async fetchTradingFee(symbol, params = {}) {
         if (!this.has['fetchTradingFees']) {
-            throw new NotSupported (this.id + ' fetchTradingFee() is not supported yet');
+            throw new NotSupported(this.id + ' fetchTradingFee() is not supported yet');
         }
-        return await this.fetchTradingFees (params);
+        return await this.fetchTradingFees(params);
     }
 
-    parseOpenInterest (interest, market = undefined) {
-        throw new NotSupported (this.id + ' parseOpenInterest () is not supported yet');
+    parseOpenInterest(interest, market = undefined) {
+        throw new NotSupported(this.id + ' parseOpenInterest () is not supported yet');
     }
 
-    parseOpenInterests (response, market = undefined, since = undefined, limit = undefined) {
+    parseOpenInterests(response, market = undefined, since = undefined, limit = undefined) {
         const interests = [];
         for (let i = 0; i < response.length; i++) {
             const entry = response[i];
-            const interest = this.parseOpenInterest (entry, market);
-            interests.push (interest);
+            const interest = this.parseOpenInterest(entry, market);
+            interests.push(interest);
         }
-        const sorted = this.sortBy (interests, 'timestamp');
-        const symbol = this.safeString (market, 'symbol');
-        return this.filterBySymbolSinceLimit (sorted, symbol, since, limit);
+        const sorted = this.sortBy(interests, 'timestamp');
+        const symbol = this.safeString(market, 'symbol');
+        return this.filterBySymbolSinceLimit(sorted, symbol, since, limit);
     }
 
-    async fetchFundingRate (symbol, params = {}) {
+    async fetchFundingRate(symbol, params = {}) {
         if (this.has['fetchFundingRates']) {
-            await this.loadMarkets ();
-            const market = this.market (symbol);
+            await this.loadMarkets();
+            const market = this.market(symbol);
             if (!market['contract']) {
-                throw new BadSymbol (this.id + ' fetchFundingRate() supports contract markets only');
+                throw new BadSymbol(this.id + ' fetchFundingRate() supports contract markets only');
             }
-            const rates = await this.fetchFundingRates ([ symbol ], params);
-            const rate = this.safeValue (rates, symbol);
+            const rates = await this.fetchFundingRates([symbol], params);
+            const rate = this.safeValue(rates, symbol);
             if (rate === undefined) {
-                throw new NullResponse (this.id + ' fetchFundingRate () returned no data for ' + symbol);
+                throw new NullResponse(this.id + ' fetchFundingRate () returned no data for ' + symbol);
             } else {
                 return rate;
             }
         } else {
-            throw new NotSupported (this.id + ' fetchFundingRate () is not supported yet');
+            throw new NotSupported(this.id + ' fetchFundingRate () is not supported yet');
         }
     }
 
-    async fetchMarkOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+    async fetchMarkOHLCV(symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         /**
          * @method
          * @name exchange#fetchMarkOHLCV
@@ -2955,13 +2955,13 @@ module.exports = class Exchange {
             const request = {
                 'price': 'mark',
             };
-            return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
+            return await this.fetchOHLCV(symbol, timeframe, since, limit, this.extend(request, params));
         } else {
-            throw new NotSupported (this.id + ' fetchMarkOHLCV () is not supported yet');
+            throw new NotSupported(this.id + ' fetchMarkOHLCV () is not supported yet');
         }
     }
 
-    async fetchIndexOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+    async fetchIndexOHLCV(symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         /**
          * @method
          * @name exchange#fetchIndexOHLCV
@@ -2977,13 +2977,13 @@ module.exports = class Exchange {
             const request = {
                 'price': 'index',
             };
-            return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
+            return await this.fetchOHLCV(symbol, timeframe, since, limit, this.extend(request, params));
         } else {
-            throw new NotSupported (this.id + ' fetchIndexOHLCV () is not supported yet');
+            throw new NotSupported(this.id + ' fetchIndexOHLCV () is not supported yet');
         }
     }
 
-    async fetchPremiumIndexOHLCV (symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
+    async fetchPremiumIndexOHLCV(symbol, timeframe = '1m', since = undefined, limit = undefined, params = {}) {
         /**
          * @method
          * @name exchange#fetchPremiumIndexOHLCV
@@ -2999,31 +2999,31 @@ module.exports = class Exchange {
             const request = {
                 'price': 'premiumIndex',
             };
-            return await this.fetchOHLCV (symbol, timeframe, since, limit, this.extend (request, params));
+            return await this.fetchOHLCV(symbol, timeframe, since, limit, this.extend(request, params));
         } else {
-            throw new NotSupported (this.id + ' fetchPremiumIndexOHLCV () is not supported yet');
+            throw new NotSupported(this.id + ' fetchPremiumIndexOHLCV () is not supported yet');
         }
     }
 
-    handleTimeInForce (params = {}) {
+    handleTimeInForce(params = {}) {
         /**
          * @ignore
          * @method
          * * Must add timeInForce to this.options to use this method
          * @return {string} returns the exchange specific value for timeInForce
          */
-        const timeInForce = this.safeStringUpper (params, 'timeInForce'); // supported values GTC, IOC, PO
+        const timeInForce = this.safeStringUpper(params, 'timeInForce'); // supported values GTC, IOC, PO
         if (timeInForce !== undefined) {
-            const exchangeValue = this.safeString (this.options['timeInForce'], timeInForce);
+            const exchangeValue = this.safeString(this.options['timeInForce'], timeInForce);
             if (exchangeValue === undefined) {
-                throw new ExchangeError (this.id + ' does not support timeInForce "' + timeInForce + '"');
+                throw new ExchangeError(this.id + ' does not support timeInForce "' + timeInForce + '"');
             }
             return exchangeValue;
         }
         return undefined;
     }
 
-    convertTypeToAccount (account) {
+    convertTypeToAccount(account) {
         /**
          * @ignore
          * @method
@@ -3031,19 +3031,19 @@ module.exports = class Exchange {
          * @param {string} account key for account name in this.options['accountsByType']
          * @returns the exchange specific account name or the isolated margin id for transfers
          */
-        const accountsByType = this.safeValue (this.options, 'accountsByType', {});
-        const lowercaseAccount = account.toLowerCase ();
+        const accountsByType = this.safeValue(this.options, 'accountsByType', {});
+        const lowercaseAccount = account.toLowerCase();
         if (lowercaseAccount in accountsByType) {
             return accountsByType[lowercaseAccount];
         } else if ((account in this.markets) || (account in this.markets_by_id)) {
-            const market = this.market (account);
+            const market = this.market(account);
             return market['id'];
         } else {
             return account;
         }
     }
 
-    checkRequiredArgument (methodName, argument, argumentName, options = []) {
+    checkRequiredArgument(methodName, argument, argumentName, options = []) {
         /**
          * @ignore
          * @method
@@ -3054,17 +3054,17 @@ module.exports = class Exchange {
          * @returns {undefined}
          */
         const optionsLength = options.length;
-        if ((argument === undefined) || ((optionsLength > 0) && (!(this.inArray (argument, options))))) {
-            const messageOptions = options.join (', ');
+        if ((argument === undefined) || ((optionsLength > 0) && (!(this.inArray(argument, options))))) {
+            const messageOptions = options.join(', ');
             let message = this.id + ' ' + methodName + '() requires a ' + argumentName + ' argument';
             if (messageOptions !== '') {
                 message += ', one of ' + '(' + messageOptions + ')';
             }
-            throw new ArgumentsRequired (message);
+            throw new ArgumentsRequired(message);
         }
     }
 
-    checkRequiredMarginArgument (methodName, symbol, marginMode) {
+    checkRequiredMarginArgument(methodName, symbol, marginMode) {
         /**
          * @ignore
          * @method
@@ -3073,23 +3073,23 @@ module.exports = class Exchange {
          * @param {string} marginMode is either 'isolated' or 'cross'
          */
         if ((marginMode === 'isolated') && (symbol === undefined)) {
-            throw new ArgumentsRequired (this.id + ' ' + methodName + '() requires a symbol argument for isolated margin');
+            throw new ArgumentsRequired(this.id + ' ' + methodName + '() requires a symbol argument for isolated margin');
         } else if ((marginMode === 'cross') && (symbol !== undefined)) {
-            throw new ArgumentsRequired (this.id + ' ' + methodName + '() cannot have a symbol argument for cross margin');
+            throw new ArgumentsRequired(this.id + ' ' + methodName + '() cannot have a symbol argument for cross margin');
         }
     }
 
-    checkRequiredSymbol (methodName, symbol) {
+    checkRequiredSymbol(methodName, symbol) {
         /**
          * @ignore
          * @method
          * @param {string} symbol unified symbol of the market
          * @param {string} methodName name of the method that requires a symbol
          */
-        this.checkRequiredArgument (methodName, symbol, 'symbol');
+        this.checkRequiredArgument(methodName, symbol, 'symbol');
     }
 
-    parseDepositWithdrawFees (response, codes = undefined, currencyIdKey = undefined) {
+    parseDepositWithdrawFees(response, codes = undefined, currencyIdKey = undefined) {
         /**
          * @ignore
          * @method
@@ -3099,26 +3099,26 @@ module.exports = class Exchange {
          * @returns {object} objects with withdraw and deposit fees, indexed by currency codes
          */
         const depositWithdrawFees = {};
-        codes = this.marketCodes (codes);
-        const isArray = Array.isArray (response);
+        codes = this.marketCodes(codes);
+        const isArray = Array.isArray(response);
         let responseKeys = response;
         if (!isArray) {
-            responseKeys = Object.keys (response);
+            responseKeys = Object.keys(response);
         }
         for (let i = 0; i < responseKeys.length; i++) {
             const entry = responseKeys[i];
             const dictionary = isArray ? entry : response[entry];
-            const currencyId = isArray ? this.safeString (dictionary, currencyIdKey) : entry;
-            const currency = this.safeValue (this.currencies_by_id, currencyId);
-            const code = this.safeString (currency, 'code', currencyId);
-            if ((codes === undefined) || (this.inArray (code, codes))) {
-                depositWithdrawFees[code] = this.parseDepositWithdrawFee (dictionary, currency);
+            const currencyId = isArray ? this.safeString(dictionary, currencyIdKey) : entry;
+            const currency = this.safeValue(this.currencies_by_id, currencyId);
+            const code = this.safeString(currency, 'code', currencyId);
+            if ((codes === undefined) || (this.inArray(code, codes))) {
+                depositWithdrawFees[code] = this.parseDepositWithdrawFee(dictionary, currency);
             }
         }
         return depositWithdrawFees;
     }
 
-    depositWithdrawFee (info) {
+    depositWithdrawFee(info) {
         return {
             'info': info,
             'withdraw': {
@@ -3133,7 +3133,7 @@ module.exports = class Exchange {
         };
     }
 
-    assignDefaultDepositWithdrawFees (fee, currency = undefined) {
+    assignDefaultDepositWithdrawFees(fee, currency = undefined) {
         /**
          * @ignore
          * @method
@@ -3142,14 +3142,14 @@ module.exports = class Exchange {
          * @param {object} currency A currency structure, the response from this.currency ()
          * @returns {object} A deposit withdraw fee structure
          */
-        const networkKeys = Object.keys (fee['networks']);
+        const networkKeys = Object.keys(fee['networks']);
         const numNetworks = networkKeys.length;
         if (numNetworks === 1) {
             fee['withdraw'] = fee['networks'][networkKeys[0]]['withdraw'];
             fee['deposit'] = fee['networks'][networkKeys[0]]['deposit'];
             return fee;
         }
-        const currencyCode = this.safeString (currency, 'code');
+        const currencyCode = this.safeString(currency, 'code');
         for (let i = 0; i < numNetworks; i++) {
             const network = networkKeys[i];
             if (network === currencyCode) {

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2034,10 +2034,12 @@ module.exports = class Exchange {
 
     async fetch2(path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined, config = {}, context = {}) {
         if (this.enableRateLimit) {
-            const cost = this.calculateRateLimiterCost(api, method, path, params, config, context);
-            await this.throttle(cost, path, params?.customExpireInterval, params?.customPriority);
+            const customExpireInterval = params?.customExpireInterval;
+            const customPriority = params?.customPriority;
             delete params?.customExpireInterval;
             delete params?.customPriority;
+            const cost = this.calculateRateLimiterCost(api, method, path, params, config, context);
+            await this.throttle(cost, path, customExpireInterval, customPriority);
         }
         this.lastRestRequestTimestamp = this.milliseconds();
         const request = this.sign(path, api, method, params, headers, body);

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -2035,7 +2035,7 @@ module.exports = class Exchange {
     async fetch2(path, api = 'public', method = 'GET', params = {}, headers = undefined, body = undefined, config = {}, context = {}) {
         if (this.enableRateLimit) {
             const cost = this.calculateRateLimiterCost(api, method, path, params, config, context);
-            await this.throttle(cost, path, params?.customThrottleConfig);
+            await this.throttle(cost, path, params?.customExpireInterval, params?.customPriority);
             delete params?.customExpireInterval;
             delete params?.customPriority;
         }

--- a/js/base/functions.js
+++ b/js/base/functions.js
@@ -3,27 +3,28 @@
 
 /*  ------------------------------------------------------------------------ */
 
-const { unCamelCase } = require ('./functions/string')
+const { unCamelCase } = require('./functions/string')
 
 const unCamelCasePropertyNames = x => {
-    for (const k in x) x[unCamelCase (k)] = x[k] // camel_case_method = camelCaseMethod
+    for (const k in x) x[unCamelCase(k)] = x[k] // camel_case_method = camelCaseMethod
     return x
 }
 
 /*  ------------------------------------------------------------------------ */
 
-module.exports = unCamelCasePropertyNames (Object.assign ({}
+module.exports = unCamelCasePropertyNames(Object.assign({}
 
-    , require ('./functions/platform')
-    , require ('./functions/generic')
-    , require ('./functions/string')
-    , require ('./functions/type')
-    , require ('./functions/number')
-    , require ('./functions/encode')
-    , require ('./functions/crypto')
-    , require ('./functions/time')
-    , require ('./functions/throttle')
-    , require ('./functions/misc')
+    , require('./functions/platform')
+    , require('./functions/generic')
+    , require('./functions/string')
+    , require('./functions/type')
+    , require('./functions/number')
+    , require('./functions/encode')
+    , require('./functions/crypto')
+    , require('./functions/time')
+    , require('./functions/throttle')
+    , require('./functions/customThrottle')
+    , require('./functions/misc')
 ))
 
 /*  ------------------------------------------------------------------------ */

--- a/js/base/functions/customThrottle.js
+++ b/js/base/functions/customThrottle.js
@@ -80,8 +80,8 @@ class Throttle {
     }
 }
 
-function customThrottle(config, path = undefined, customPriority = undefined, customExpireInterval = undefined) {
-    function inner(cost = undefined, path = undefined, customPriority = undefined, customExpireInterval = undefined) {
+function customThrottle(config, path = undefined, customExpireInterval = undefined, customPriority = undefined) {
+    function inner(cost = undefined, path = undefined, customThrottleConfig) {
         let resolver;
         let rejecter;
         const promise = new Promise((resolve, reject) => {

--- a/js/base/functions/customThrottle.js
+++ b/js/base/functions/customThrottle.js
@@ -103,10 +103,8 @@ function customThrottle(config, path = undefined, customExpireInterval = undefin
         }
 
         let expireInterval;
-        console.log('customExpireInterval', customExpireInterval)
         if (customExpireInterval !== undefined) {
             expireInterval = customExpireInterval;
-            console.log('customExpireInterval', customExpireInterval)
         } else if (path !== undefined) {
             expireInterval = this.config['expireIntervals'][path];
         }

--- a/js/base/functions/customThrottle.js
+++ b/js/base/functions/customThrottle.js
@@ -81,7 +81,7 @@ class Throttle {
 }
 
 function customThrottle(config, path = undefined, customExpireInterval = undefined, customPriority = undefined) {
-    function inner(cost = undefined, path = undefined, customThrottleConfig) {
+    function inner(cost = undefined, path = undefined, customExpireInterval = undefined, customPriority = undefined) {
         let resolver;
         let rejecter;
         const promise = new Promise((resolve, reject) => {
@@ -103,8 +103,10 @@ function customThrottle(config, path = undefined, customExpireInterval = undefin
         }
 
         let expireInterval;
+        console.log('customExpireInterval', customExpireInterval)
         if (customExpireInterval !== undefined) {
             expireInterval = customExpireInterval;
+            console.log('customExpireInterval', customExpireInterval)
         } else if (path !== undefined) {
             expireInterval = this.config['expireIntervals'][path];
         }

--- a/js/base/functions/customThrottle.js
+++ b/js/base/functions/customThrottle.js
@@ -17,7 +17,7 @@ class Throttle {
             cost: 1.0,
             priorities: {},
             expireIntervals: {
-                'myTrades': 1000 * 1,
+                'myTrades': 1000 * 50, // 50 seconds
             },
         };
         Object.assign(this.config, config);
@@ -82,7 +82,6 @@ class Throttle {
 
 function customThrottle(config, path = undefined, customPriority = undefined, customExpireInterval = undefined) {
     function inner(cost = undefined, path = undefined, customPriority = undefined, customExpireInterval = undefined) {
-        console.log('customThrottle')
         let resolver;
         let rejecter;
         const promise = new Promise((resolve, reject) => {

--- a/js/base/functions/customThrottle.js
+++ b/js/base/functions/customThrottle.js
@@ -1,0 +1,141 @@
+"use strict";
+
+/*  ------------------------------------------------------------------------ */
+
+const { now, sleep } = require('./time');
+
+/*  ------------------------------------------------------------------------ */
+
+class Throttle {
+    constructor(config) {
+        this.config = {
+            refillRate: 1.0,
+            delay: 0.001,
+            capacity: 1.0,
+            maxCapacity: 2000,
+            tokens: 0,
+            cost: 1.0,
+            priorities: {},
+            expireIntervals: {
+                'myTrades': 1000 * 1,
+            },
+        };
+        Object.assign(this.config, config);
+        this.queue = [];
+        this.priorityQueue = {};
+        this.running = false;
+    }
+
+    /**
+     * Returns the most important queue (lower number => hight priority), if there are no priorities, returns the normal queue
+     */
+    getMostImportantQueue() {
+        const prioritieIndices = Object.keys(this.priorityQueue);
+        let highestPriorityIndex = 0;
+        let highestPriorityQueue = this.queue;
+
+        if (prioritieIndices.length !== 0) {
+            highestPriorityIndex = Math.min(...prioritieIndices);
+            highestPriorityQueue = this.priorityQueue[highestPriorityIndex];
+        }
+        return {
+            highestPriorityQueue,
+            highestPriorityIndex
+        };
+    }
+
+    async loop() {
+        let lastTimestamp = now();
+        while (this.running) {
+            const { highestPriorityQueue, highestPriorityIndex } = this.getMostImportantQueue();
+
+            const { resolver, cost, rejecter, timestamp, expireInterval } = highestPriorityQueue[0];
+
+            if (this.config['tokens'] >= 0) {
+                // check if the request is expired
+                if (expireInterval !== undefined && timestamp + expireInterval < now()) {
+                    rejecter(new Error('Request expired'));
+                } else {
+                    this.config['tokens'] -= cost;
+                    resolver();
+                }
+                highestPriorityQueue.shift();
+                // contextswitch
+                await Promise.resolve();
+                if (highestPriorityQueue.length === 0) {
+                    delete this.priorityQueue[highestPriorityIndex];
+                }
+                if (this.queue.length === 0 && Object.keys(this.priorityQueue).length === 0) {
+                    this.running = false;
+                }
+            } else {
+                await sleep(this.config['delay'] * 1000);
+                const current = now();
+                const elapsed = current - lastTimestamp;
+                lastTimestamp = current;
+                const tokens = this.config['tokens'] + (this.config['refillRate'] * elapsed);
+                this.config['tokens'] = Math.min(tokens, this.config['capacity']);
+            }
+        }
+    }
+}
+
+function customThrottle(config, path = undefined, customPriority = undefined, customExpireInterval = undefined) {
+    function inner(cost = undefined, path = undefined, customPriority = undefined, customExpireInterval = undefined) {
+        console.log('customThrottle')
+        let resolver;
+        let rejecter;
+        const promise = new Promise((resolve, reject) => {
+            resolver = resolve;
+            rejecter = reject;
+        });
+
+        // TODO manage capacity for both queues
+        if (this.queue.length > this.config['maxCapacity']) {
+            throw new Error('throttle queue is over maxCapacity (' + this.config['maxCapacity'].toString() + '), see https://github.com/ccxt/ccxt/issues/11645#issuecomment-1195695526');
+        }
+        cost = (cost === undefined) ? this.config['cost'] : cost;
+
+        let priority;
+        if (customPriority !== undefined) {
+            priority = customPriority;
+        } else if (path !== undefined) {
+            priority = this.config['priorities'][path];
+        }
+
+        let expireInterval;
+        if (customExpireInterval !== undefined) {
+            expireInterval = customExpireInterval;
+        } else if (path !== undefined) {
+            expireInterval = this.config['expireIntervals'][path];
+        }
+
+        if (priority !== undefined) {
+            if (this.priorityQueue[priority] === undefined) {
+                this.priorityQueue[priority] = [];
+            }
+            this.priorityQueue[priority].push({ resolver, cost, rejecter, timestamp: now(), expireInterval });
+        } else {
+            this.queue.push({ resolver, cost, rejecter, timestamp: now(), expireInterval });
+        }
+
+        if (!this.running) {
+            this.running = true;
+            this.loop();
+        }
+        return promise;
+    }
+    const instance = new Throttle(config);
+    const bound = inner.bind(instance);
+    // useful for inspecting the tokenBucket
+    bound.config = instance.config;
+    bound.priorityQueue = instance.priorityQueue;
+    bound.queue = instance.queue;
+    return bound;
+}
+
+module.exports = {
+    customThrottle,
+};
+
+// ----------------------------------------

--- a/js/coinbase.js
+++ b/js/coinbase.js
@@ -843,6 +843,7 @@ module.exports = class coinbase extends Exchange {
         const costString = this.safeString (subtotalObject, 'amount', v3Cost);
         let priceString = undefined;
         let cost = undefined;
+        let amount = undefined;
         if ((costString !== undefined) && (amountString !== undefined)) {
             priceString = Precise.stringDiv (costString, amountString);
         } else {
@@ -852,6 +853,11 @@ module.exports = class coinbase extends Exchange {
             cost = Precise.stringMul (priceString, amountString);
         } else {
             cost = costString;
+        }
+        if((costString !== undefined) && (amountString === undefined) && (priceString !== undefined)) {
+            amount = Precise.stringDiv(costString, priceString);
+        } else {
+            amount = amountString;
         }
         const feeCurrencyId = this.safeString (feeObject, 'currency');
         const datetime = this.safeStringN (trade, [ 'created_at', 'trade_time', 'time' ]);
@@ -868,7 +874,7 @@ module.exports = class coinbase extends Exchange {
             'side': (side === 'unknown_order_side') ? undefined : side,
             'takerOrMaker': (takerOrMaker === 'unknown_liquidity_indicator') ? undefined : takerOrMaker,
             'price': priceString,
-            'amount': amountString,
+            'amount': amount,
             'cost': cost,
             'fee': {
                 'cost': this.safeNumber (feeObject, 'amount', v3FeeCost),


### PR DESCRIPTION
This change updates the `decimalToPrecision` function to accept the `TRUNCATE` argument instead of the `ROUND` argument. This should work for other CEXs as well, as the `ROUND` argument rounds the amount to the higher number, which is not useful to us - it would show the error that the user doesn't have enough assets/balance.