### PR TITLE
fix: store-1343 - add underlyingNetwork to bitfinex and huobi

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedelabs/ccxt",
-  "version": "4.0.102",
+  "version": "4.0.103",
   "description": "A JavaScript / TypeScript / Python / C# / PHP cryptocurrency trading library with support for 130+ exchanges",
   "unpkg": "dist/ccxt.browser.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedelabs/ccxt",
-  "version": "4.0.103",
+  "version": "4.0.104",
   "description": "A JavaScript / TypeScript / Python / C# / PHP cryptocurrency trading library with support for 130+ exchanges",
   "unpkg": "dist/ccxt.browser.js",
   "type": "module",

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2770,6 +2770,14 @@ export default class Exchange {
         return [ networkCodeInParams, params ];
     }
 
+    handleEcidAndParams (params) {
+        const ecidInParams = this.safeString2 (params, 'ecid', 'network');
+        if (ecidInParams !== undefined) {
+            params = this.omit (params, [ 'ecid', 'network' ]);
+        }
+        return [ ecidInParams, params ];
+    }
+
     defaultNetworkCode (currencyCode) {
         let defaultNetworkCode = undefined;
         const defaultNetworks = this.safeValue (this.options, 'defaultNetworks', {});

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -750,8 +750,7 @@ export default class bitfinex2 extends Exchange {
                     networks[network] = {
                         'info': networkId,
                         'id': networkId.toLowerCase (),
-                        'network': networkId,
-                        'underlyingNetwork': network,
+                        'network': network,
                         'active': undefined,
                         'deposit': undefined,
                         'withdraw': undefined,
@@ -776,6 +775,7 @@ export default class bitfinex2 extends Exchange {
     }
 
     safeNetwork (networkId) {
+        // mapping method to network
         const networksById = {
             'BITCOIN': 'BTC',
             'LITECOIN': 'LTC',

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -779,6 +779,7 @@ export default class bitfinex2 extends Exchange {
         const networksById = {
             'BITCOIN': 'BTC',
             'LITECOIN': 'LTC',
+            'ETHEREUM': 'ETH',
             'ERC20': 'ETH',
             'TETHERUSE': 'ETH',
             'TETHERUSO': 'OMNI',
@@ -805,9 +806,11 @@ export default class bitfinex2 extends Exchange {
             'TETHERUSDTZK': 'ZK2',
             'XAUT': 'ETH',
             'CNHT': 'ETH',
-            'EUT': 'BSC',
+            'EUT': 'ETH',
             'MXNT': 'ETH',
             'NEOGAS': 'NEO',
+            'LES': 'EOS',
+            'LET': 'ETH',
         };
         return this.safeString (networksById, networkId, networkId);
     }

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -746,11 +746,12 @@ export default class bitfinex2 extends Exchange {
                 const networkId = this.safeString (pair, 0);
                 const currencyId = this.safeString (this.safeValue (pair, 1, []), 0);
                 if (currencyId === cleanId) {
-                    const network = this.safeNetwork (networkId);
+                    const network = rawType ?? this.safeNetwork (networkId);
                     networks[network] = {
                         'info': networkId,
                         'id': networkId.toLowerCase (),
                         'network': networkId,
+                        'underlyingNetwork': network,
                         'active': undefined,
                         'deposit': undefined,
                         'withdraw': undefined,
@@ -778,19 +779,36 @@ export default class bitfinex2 extends Exchange {
         const networksById = {
             'BITCOIN': 'BTC',
             'LITECOIN': 'LTC',
-            'ETHEREUM': 'ERC20',
-            'TETHERUSE': 'ERC20',
+            'ERC20': 'ETH',
+            'TETHERUSE': 'ETH',
             'TETHERUSO': 'OMNI',
             'TETHERUSL': 'LIQUID',
-            'TETHERUSX': 'TRC20',
+            'TETHERUSX': 'TRX',
             'TETHERUSS': 'EOS',
             'TETHERUSDTAVAX': 'AVAX',
             'TETHERUSDTSOL': 'SOL',
-            'TETHERUSDTALG': 'ALGO',
+            'TETHERUSDTALG': 'ALG',
             'TETHERUSDTBCH': 'BCH',
             'TETHERUSDTKSM': 'KSM',
             'TETHERUSDTDVF': 'DVF',
             'TETHERUSDTOMG': 'OMG',
+            'TETHERUSDTXTZ': 'XTZ',
+            'TETHERUSDTNEAR': 'NEAR',
+            'TETHERUSDTDOT': 'DOT',
+            'TETHERUSDTPLY': 'PLY',
+            'TETHERUSDTKAVA': 'KAVA',
+            'TETHERMXNTE': 'ETH',
+            'TETHERXAUTE': 'ETH',
+            'TETHEREUE': 'ETH',
+            'TETHERCNHTX': 'ETH',
+            'TETHERCNHTE': 'ETH',
+            'TETHERUSDTZK': 'ZK2',
+            'XAUT': 'ETH',
+            'CNHT': 'ETH',
+            'EUT': 'BSC',
+            'MXNT': 'ETH',
+            'NEOGAS': 'NEO',
+            'MATICM': 'NEO',
         };
         return this.safeString (networksById, networkId, networkId);
     }

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -808,7 +808,6 @@ export default class bitfinex2 extends Exchange {
             'EUT': 'BSC',
             'MXNT': 'ETH',
             'NEOGAS': 'NEO',
-            'MATICM': 'NEO',
         };
         return this.safeString (networksById, networkId, networkId);
     }

--- a/ts/src/huobi.ts
+++ b/ts/src/huobi.ts
@@ -2881,8 +2881,8 @@ export default class huobi extends Exchange {
             'roco': 'cchain',
             'fio': 'cchain',
             'hec': 'cchain',
-            'gmx': 'cchain', // Not sure, as it's tagged as `cchainerc20`
-            'xeta': 'cchain', // Not sure, as it's tagged as `cchainerc20`
+            'gmx': 'cchain',
+            'xeta': 'cchain',
             'kube': 'ADA',
             'nt': 'erc20',
             'solo': 'xrp',


### PR DESCRIPTION
Underlying networks is needed in order to avoid pushing methods to the `network` prop which could be used to withdraw

Actually we didn't modify the actual behavior of the exchange but added a key in order to map the network with our internal network, these keys aren't internal keys but external keys, so it's not mixed up with our internal mapping

## Huobi

My dear Huobi, thanks a lot for this hard time managing to map your networks properly, in order to achieve it I had to:

- Generate methods with a pattern (currencyName + network, network + currencyName (example: usdcerc20 or erc20usdc)
- Add it to a mapping object with method as a key, `ecid` as a value
- consume it to display the underlying network