### PR TITLE
refactor: deposit methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedelabs/ccxt",
-  "version": "4.0.110",
+  "version": "4.0.111",
   "description": "A JavaScript / TypeScript / Python / C# / PHP cryptocurrency trading library with support for 130+ exchanges",
   "unpkg": "dist/ccxt.browser.js",
   "type": "module",

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -2717,8 +2717,17 @@ export default class Exchange {
                 const networkCodeReplacements = this.safeValue (this.options, 'networkCodeReplacements', {});
                 if (currencyCode in networkCodeReplacements) {
                     // if there is a replacement for the passed networkCode, then we use it to find network-id in `options->networks` object
-                    const replacementObject = networkCodeReplacements[currencyCode]; // i.e. { 'ERC20': 'ETH' }, where 'ETH' is the networkCode
-                    networkId = this.safeString (replacementObject, networkCode);
+                    const replacementObject = networkCodeReplacements[currencyCode];
+                    const keys = Object.keys (replacementObject);
+                    for (let i = 0; i < keys.length; i++) {
+                        const key = keys[i];
+                        const value = replacementObject[key];
+                        // if value matches to provided unified networkCode, then we use it's key to find network-id in `options->networks` object
+                        if (value === networkCode) {
+                            networkId = key;
+                            break;
+                        }
+                    }
                 }
                 // if it wasn't found, we just set the provided value to network-id
                 if (networkId === undefined) {
@@ -4544,6 +4553,6 @@ export default class Exchange {
 }
 
 export {
-    Exchange,
+    Exchange
 };
 

--- a/ts/src/base/types.ts
+++ b/ts/src/base/types.ts
@@ -192,6 +192,7 @@ export interface DepositAddressResponse {
     currency: string;
     address: string;
     info: any;
+    network?: string;
     tag?: string;
 }
 

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -1341,10 +1341,6 @@ export default class binance extends Exchange {
                     'explorer.zcha.in': 'ZEC',
                     'explorer.zensystem.io': 'ZEN',
                 },
-                'impliedNetworks': {
-                    'ETH': { 'ERC20': 'ETH' },
-                    'TRX': { 'TRC20': 'TRX' },
-                },
                 'legalMoney': {
                     'MXN': true,
                     'UGX': true,
@@ -5911,28 +5907,6 @@ export default class binance extends Exchange {
         //     }
         //
         const address = this.safeString (response, 'address');
-        const url = this.safeString (response, 'url');
-        let impliedNetwork = undefined;
-        if (url !== undefined) {
-            const reverseNetworks = this.safeValue (this.options, 'reverseNetworks', {});
-            const parts = url.split ('/');
-            let topLevel = this.safeString (parts, 2);
-            if ((topLevel === 'blockchair.com') || (topLevel === 'viewblock.io')) {
-                const subLevel = this.safeString (parts, 3);
-                if (subLevel !== undefined) {
-                    topLevel = topLevel + '/' + subLevel;
-                }
-            }
-            impliedNetwork = this.safeString (reverseNetworks, topLevel);
-            const impliedNetworks = this.safeValue (this.options, 'impliedNetworks', {
-                'ETH': { 'ERC20': 'ETH' },
-                'TRX': { 'TRC20': 'TRX' },
-            });
-            if (code in impliedNetworks) {
-                const conversion = this.safeValue (impliedNetworks, code, {});
-                impliedNetwork = this.safeString (conversion, impliedNetwork, impliedNetwork);
-            }
-        }
         let tag = this.safeString (response, 'tag', '');
         if (tag.length === 0) {
             tag = undefined;
@@ -5942,7 +5916,6 @@ export default class binance extends Exchange {
             'currency': code,
             'address': address,
             'tag': tag,
-            'network': impliedNetwork,
             'info': response,
         };
     }

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -4822,12 +4822,13 @@ export default class bybit extends Exchange {
         const tag = this.safeString (depositAddress, 'tagDeposit');
         const code = this.safeString (currency, 'code');
         const chain = this.safeString (depositAddress, 'chain');
+        const network = this.networkIdToCode (chain);
         this.checkAddress (address);
         return {
             'currency': code,
             'address': address,
             'tag': tag,
-            'network': chain,
+            'network': network,
             'info': depositAddress,
         };
     }

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -497,12 +497,11 @@ export default class coinbase extends Exchange {
         const currencyIdV3 = this.safeString (account, 'currency');
         const currency = this.safeValue (account, 'currency', {});
         const currencyId = this.safeString (currency, 'code', currencyIdV3);
-        const typeV3 = this.safeString (account, 'name');
+        const typeV3 = this.safeString (account, 'type'); // ACCOUNT_TYPE_FIAT or ACCOUNT_TYPE_CRYPTO
         const typeV2 = this.safeString (account, 'type');
-        const parts = typeV3.split (' ');
         return {
             'id': this.safeString2 (account, 'id', 'uuid'),
-            'type': (active !== undefined) ? this.safeStringLower (parts, 1) : typeV2,
+            'type': (active !== undefined) ? typeV3 : typeV2,
             'code': this.safeCurrencyCode (currencyId),
             'info': account,
             'active': active,
@@ -524,7 +523,7 @@ export default class coinbase extends Exchange {
             await this.loadAccounts ();
             for (let i = 0; i < this.accounts.length; i++) {
                 const account = this.accounts[i];
-                if (account['code'] === code && account['type'] === 'wallet') {
+                if (account['code'] === code && account['type'] === 'ACCOUNT_TYPE_CRYPTO') {
                     accountId = account['id'];
                     break;
                 }
@@ -576,10 +575,12 @@ export default class coinbase extends Exchange {
         const data = this.safeValue (response, 'data', {});
         const tag = this.safeString (data, 'destination_tag');
         const address = this.safeString (data, 'address');
+        const network = this.safeString (data, 'network');
         return {
             'currency': code,
             'tag': tag,
             'address': address,
+            'network': network,
             'info': response,
         };
     }

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -891,7 +891,7 @@ export default class kucoin extends Exchange {
             const chainsLength = chains.length;
             for (let j = 0; j < chainsLength; j++) {
                 const chain = chains[j];
-                const chainId = this.safeString (chain, 'chain');
+                const chainId = this.safeString (chain, 'chainId');
                 const networkCode = this.networkIdToCode (chainId);
                 const isWithdrawalEnabled = this.safeValue (chain, 'isWithdrawEnabled', false);
                 const isDepositEnabled = this.safeValue (chain, 'isDepositEnabled', false);
@@ -1476,7 +1476,7 @@ export default class kucoin extends Exchange {
             'currency': code,
             'address': address,
             'tag': this.safeString (depositAddress, 'memo'),
-            'network': this.networkIdToCode (this.safeString (depositAddress, 'chain')),
+            // it's hard to retrieve the network here, the api returns the chain name, not the id
         };
     }
 


### PR DESCRIPTION
Checked all exchanges for the deposit use case and fixed issues:
- `ts/src/base/Exchange.ts` - I made a mistake the last time by modyfing `networkCodeToId` function. I though that networkCodeReplacements was a mapping (`currencyCode` + `networkCode`) => `networkId`. Actually, it was  (`currencyCode` + `networkCode`) => `replacedNetworkCode`
- in `binance` class, removed the whole section related to the `implied network`. It transforms the link of the blockchain explorer to the network. Since it might be a source of error (the mapping is not really maintained) and we don't want to put that much effort to maintain it - I removed
- in `bitget`, changes are related to the 1 point: that's why I renamed the options' property
- in `coinbase`, the we couldn't compare the value to `wallet`, because the parser was outdated. Most of the time it was returning `en` instead of `wallet`. 
- In `kucoin`, we cannot really map the chain name to the chain id and then to the network code

Before to review the [associated PR in the monorepo](https://github.com/cedelabs/monorepo/pull/1096), ping @neeeekitos to bump the version of ccxt in the monorepo, it will fix tests in the CI.