### PR TITLE
fetchticker V3 endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedelabs/ccxt",
-  "version": "4.0.113",
+  "version": "4.0.114",
   "description": "A JavaScript / TypeScript / Python / C# / PHP cryptocurrency trading library with support for 130+ exchanges",
   "unpkg": "dist/ccxt.browser.js",
   "type": "module",


### PR DESCRIPTION
I migrated an endpoint to the last version because rate limiting for the V1 is lower than expected in CCXT and it creates rate limiting errors