### PR TITLE
fix: binance withdraw history endpoint

### DIFF
--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -288,7 +288,7 @@ export default class binance extends Exchange {
                         'capital/deposit/hisrec': 0.1,
                         'capital/deposit/subAddress': 0.1,
                         'capital/deposit/subHisrec': 0.1,
-                        'capital/withdraw/history': 1800, // Weight(IP): 18000 => cost = 0.1 * 18000 = 1800
+                        'capital/withdraw/history': 5, // globalRateLimit / endpointRateLimit = 50 / 10 = 5
                         'capital/contract/convertible-coins': 4.0002, // Weight(UID): 600 => cost = 0.006667 * 600 = 4.0002
                         'convert/tradeFlow': 20.001, // Weight(UID): 3000 => cost = 0.006667 * 3000 = 20.001
                         'convert/exchangeInfo': 50,


### PR DESCRIPTION
The weight of the withdraw history endpoint was too heavy and makes the fetching process very slow. I decided to update the cost by following the doc https://www.notion.so/cede-labs/CCXT-Internal-documentation-13e4c5acc36c4320be6649e476b8068b?pvs=4#e673d9e2300a4ed8b49fe0b947779ff9