### PR TITLE
fix: kraken withdrawal

### DIFF
--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -2648,15 +2648,20 @@ export default class kraken extends Exchange {
          * @returns {object} a [transaction structure]{@link https://docs.ccxt.com/#/?id=transaction-structure}
          */
         [ tag, params ] = this.handleWithdrawTagAndParams (tag, params);
-        this.checkAddress (address);
+        // address is optional
+        if (address !== undefined) {
+            this.checkAddress (address);
+        }
         if ('key' in params) {
             await this.loadMarkets ();
             const currency = this.currency (code);
             const request = {
                 'asset': currency['id'],
                 'amount': amount,
-                'address': address,
             };
+            if (address) {
+                request['address'] = address;
+            }
             const response = await this.privatePostWithdraw (this.extend (request, params));
             //
             //     {


### PR DESCRIPTION
Ccxt enforced to provide the address despite it's optional. 
https://docs.kraken.com/rest/#tag/Funding/operation/withdrawFunds
Therefore, it makes the withdrawal impossible to succeed on cede.store. 
