### PR TITLE
fix: fetch method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cedelabs/ccxt",
-  "version": "4.1.85",
+  "version": "4.1.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cedelabs/ccxt",
-      "version": "4.1.85",
+      "version": "4.1.86",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cedelabs/ccxt",
-	"version": "4.1.85",
+	"version": "4.1.86",
 	"description": "A JavaScript / TypeScript / Python / C# / PHP cryptocurrency trading library with support for 130+ exchanges",
 	"unpkg": "dist/ccxt.browser.js",
 	"type": "module",

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -677,7 +677,6 @@ export default class Exchange {
         // http properties
         this.headers = {}
         // prepended to URL, like https://proxy.com/https://exchange.com/api...
-        this.proxy = ''
         this.forcedProxy = ''
         this.origin = '*' // CORS origin
         // underlying properties


### PR DESCRIPTION
The previous ccxt update changed the fetch method implementation. This update assumed `this.proxy` was undefined by default (it is in the main ccxt repo) but in our custom ccxt repo, `this.proxy` had an empty string by default. 
Therefore,
- the condition at line 1543 passed and the `checkProxyUrlSettings` returned an empty string `""`
- therefore, the conditions at lines 970, 972 and 974 passed 
-  finally, the http module was used instead of the https module. It's why we had the following error: Protocol "https:" not supported.

To fix it, I just removed the the default value assignation of `this.proxy``
