### PR TITLE
fix(store): the error is thrown if the message is not empty

### DIFF
--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -7116,7 +7116,7 @@ export default class bitget extends Exchange {
         if (nonZeroErrorCode) {
             this.throwExactlyMatchedException (this.exceptions['exact'], errorCode, userMessage);
         }
-        if (nonZeroErrorCode || nonEmptyMessage) {
+        if (nonZeroErrorCode && nonEmptyMessage) {
             throw new ExchangeError (userMessage); // unknown message
         }
         return undefined;


### PR DESCRIPTION
Bug: can't add bybit (throws an error: "00000: success" (code is 00000, error message is success)

When we add bybit, fetch currencies call throws the error cuz the `msg` parameter in the response is not empty. Now we throw errors if the error code is not zero and there is a message