### PR TITLE
fix: binance exclude fiat currencies from fetchCurrencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cedelabs/ccxt",
-  "version": "4.1.91",
+  "version": "4.1.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cedelabs/ccxt",
-      "version": "4.1.91",
+      "version": "4.1.92",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cedelabs/ccxt",
-	"version": "4.1.91",
+	"version": "4.1.92",
 	"description": "A JavaScript / TypeScript / Python / C# / PHP cryptocurrency trading library with support for 130+ exchanges",
 	"unpkg": "dist/ccxt.browser.js",
 	"type": "module",

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -1913,6 +1913,7 @@ export default class binance extends Exchange {
         }
         const response = await this.sapiGetCapitalConfigGetall (params);
         const result = {};
+        const legalMoney = this.safeValue (this.options, 'legalMoney', {});
         for (let i = 0; i < response.length; i++) {
             //
             //    {
@@ -2013,7 +2014,6 @@ export default class binance extends Exchange {
             const id = this.safeString (entry, 'coin');
             const name = this.safeString (entry, 'name');
             const code = this.safeCurrencyCode (id);
-            const legalMoney = this.safeValue (this.options, 'legalMoney', {});
             if (!(code in legalMoney)) {
                 let minPrecision = undefined;
                 let isTokenWithdrawable = false;

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -1536,6 +1536,7 @@ export default class okx extends Exchange {
     safeNetwork (networkId) {
         const networksById = {
             'Bitcoin': 'BTC',
+            'Optimism (V2)': 'Optimism',
             'Omni': 'OMNI',
             'TRON': 'TRC20',
         };


### PR DESCRIPTION
- Added more FIAT currencies to binance
- Filtered them so they are not returned form `fetchCurrencies` anymore
- Replaced Optimism v2 error on OKX to `Optimism` which is the v2 already