### PR TITLE
htx network fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedelabs/ccxt",
-  "version": "4.2.20",
+  "version": "4.2.21",
   "description": "A JavaScript / TypeScript / Python / C# / PHP cryptocurrency trading library with support for 100+ exchanges",
   "unpkg": "dist/ccxt.browser.js",
   "type": "module",

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -3166,6 +3166,7 @@ export default class htx extends Exchange {
             'ht2': 'erc20',
             'hbch': 'erc20',
             'eth': 'erc20',
+            'ETH': 'erc20',
             'rain': 'erc20',
             'xfi': 'erc20',
             'arbieth': 'arb',


### PR DESCRIPTION
https://cedelabs.atlassian.net/browse/STORE-1648
we had a bug on cede.store => two matic networks, only one was valid 
![Screenshot from 2024-02-12 12-27-12](https://github.com/cedelabs/ccxt/assets/62065633/eb70d88b-47dd-48f9-a1be-7b5717da0e21)
In the following screenshot you can see the response structure of HTX, this network is the buggy one that was mapped as a the Polygon chain (is was ethereum)
![Screenshot from 2024-02-12 12-36-20](https://github.com/cedelabs/ccxt/assets/62065633/50f6d612-9e37-418e-bcc8-2fc7dcb85640)
this is the origin of the bug, in `fetchCurrencies`, as you can see we get the ecid from either the safeCode or the safeNetwork. SafeCode is title and title value was `ETH`, safeNetwork is chain and chain is `matic`. At the end, because `ETH` is not mapped, we use the safeNetwork and it leads to an incorrect mapping. That's why I added this new mapping entry
![Screenshot from 2024-02-12 14-13-20](https://github.com/cedelabs/ccxt/assets/62065633/65b17960-2513-4486-b2f8-611e7737b343)
