### PR TITLE
amount precision fix and check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cedelabs/ccxt",
-  "version": "4.2.48",
+  "version": "4.2.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cedelabs/ccxt",
-      "version": "4.2.48",
+      "version": "4.2.49",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cedelabs/ccxt",
-  "version": "4.2.48",
+  "version": "4.2.49",
   "description": "A JavaScript / TypeScript / Python / C# / PHP cryptocurrency trading library with support for 100+ exchanges",
   "unpkg": "dist/ccxt.browser.js",
   "type": "module",

--- a/ts/src/base/Exchange.ts
+++ b/ts/src/base/Exchange.ts
@@ -5039,7 +5039,8 @@ export default class Exchange {
         if (precision === undefined) {
             return this.forceString (fee);
         } else {
-            return this.decimalToPrecision (fee, TRUNCATE, precision, this.precisionMode, this.paddingMode);
+            const result = this.decimalToPrecision (fee, TRUNCATE, precision, this.precisionMode, this.paddingMode);
+            return result;
         }
     }
 

--- a/ts/src/base/functions/number.ts
+++ b/ts/src/base/functions/number.ts
@@ -149,7 +149,7 @@ const decimalToPrecision = (
                 x = x - missing;
             }
         }
-        return decimalToPrecision (x, ROUND, newNumPrecisionDigits, DECIMAL_PLACES, paddingMode);
+        return decimalToPrecision (x, roundingMode, newNumPrecisionDigits, DECIMAL_PLACES, paddingMode);
     }
 
     /*  Convert to a string (if needed), skip leading minus sign (if any)   */

--- a/ts/src/base/functions/number.ts
+++ b/ts/src/base/functions/number.ts
@@ -87,6 +87,7 @@ function precisionFromString (str) {
         const numStr = str.replace (/\de/, '')
         return parseInt (numStr) * -1
     }
+    
     // support integer formats (without dot) like '1', '10' etc [Note: bug in decimalToPrecision, so this should not be used atm]
     // if (str.indexOf ('.') === -1) {
     //     return str.length * -1
@@ -98,12 +99,29 @@ function precisionFromString (str) {
 
 /*  ------------------------------------------------------------------------ */
 
-const decimalToPrecision = (
+const decimalToPrecisionWrapper = (
     x,
     roundingMode,
     numPrecisionDigits,
     countingMode = DECIMAL_PLACES,
     paddingMode = NO_PADDING
+) => {
+    let precision = numPrecisionDigits;
+    if (countingMode === TICK_SIZE) {
+        precision = decimalToPrecision (numPrecisionDigits, ROUND, 22, DECIMAL_PLACES, NO_PADDING);
+        precision = precisionFromString (precision);
+    }
+    x = decimalToPrecision (x, ROUND, precision+1, DECIMAL_PLACES, NO_PADDING);
+
+    return decimalToPrecision (x, roundingMode, numPrecisionDigits, countingMode, paddingMode);
+};
+
+const decimalToPrecision = (
+    x,
+    roundingMode,
+    numPrecisionDigits,
+    countingMode = DECIMAL_PLACES,
+    paddingMode = NO_PADDING,
 ) => {
     if (countingMode === TICK_SIZE) {
         if (typeof numPrecisionDigits === 'string') {
@@ -301,7 +319,7 @@ function omitZero (stringNumber) {
 export {
     numberToString,
     precisionFromString,
-    decimalToPrecision,
+    decimalToPrecisionWrapper as decimalToPrecision,
     truncate_to_string,
     truncate,
     omitZero,

--- a/ts/src/base/functions/number.ts
+++ b/ts/src/base/functions/number.ts
@@ -106,13 +106,18 @@ const decimalToPrecisionWrapper = (
     countingMode = DECIMAL_PLACES,
     paddingMode = NO_PADDING
 ) => {
+    // Turn precision value to and integer
     let precision = numPrecisionDigits;
-    if (countingMode === TICK_SIZE) {
-        precision = decimalToPrecision (numPrecisionDigits, ROUND, 22, DECIMAL_PLACES, NO_PADDING);
-        precision = precisionFromString (precision);
+    if (typeof precision === 'string') {
+        precision = parseFloat(precision)
     }
-    x = decimalToPrecision (x, ROUND, precision+1, DECIMAL_PLACES, NO_PADDING);
-
+    if (countingMode === TICK_SIZE) {
+        const precisionDigitsString = decimalToPrecision (precision, ROUND, 22, DECIMAL_PLACES, NO_PADDING);
+        precision = precisionFromString (precisionDigitsString);
+    }
+    // Eliminate rounding errors
+    x = decimalToPrecision (x, ROUND, precision+2, DECIMAL_PLACES, NO_PADDING);
+    // Round the number
     return decimalToPrecision (x, roundingMode, numPrecisionDigits, countingMode, paddingMode);
 };
 

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -5745,16 +5745,15 @@ export default class binance extends Exchange {
                 const quoteOrderQty = this.safeBool (this.options, 'quoteOrderQty', true);
                 if (quoteOrderQty) {
                     const quoteOrderQtyNew = this.safeString2 (params, 'quoteOrderQty', 'cost');
-                    const precision = market['precision']['price'];
                     if (quoteOrderQtyNew !== undefined) {
                         // We shouldn't truncate as it will break the min amount logic
-                        request['quoteOrderQty'] = this.decimalToPrecision (quoteOrderQtyNew, ROUND, precision, this.precisionMode);
+                        request['quoteOrderQty'] = this.costToPrecision (symbol, quoteOrderQtyNew);
                     } else if (price !== undefined) {
                         const amountString = this.numberToString (amount);
                         const priceString = this.numberToString (price);
                         const quoteOrderQuantity = Precise.stringMul (amountString, priceString);
                         // We shouldn't truncate as it will break the min amount logic
-                        request['quoteOrderQty'] = this.decimalToPrecision (quoteOrderQuantity, ROUND, precision, this.precisionMode);
+                        request['quoteOrderQty'] = this.costToPrecision (symbol, quoteOrderQuantity);
                     } else {
                         quantityIsRequired = true;
                     }

--- a/ts/src/binance.ts
+++ b/ts/src/binance.ts
@@ -8085,7 +8085,6 @@ export default class binance extends Exchange {
             'forceProxy': true,
             'coin': currency['id'],
             'address': address,
-            'amount': amount,
             // https://binance-docs.github.io/apidocs/spot/en/#withdraw-sapi
             // issue sapiGetCapitalConfigGetall () to get networks for withdrawing USDT ERC20 vs USDT Omni
             // 'network': 'ETH', // 'BTC', 'TRX', etc, optional
@@ -8100,6 +8099,8 @@ export default class binance extends Exchange {
             request['network'] = network;
             params = this.omit (params, 'network');
         }
+        const precisionAmount = this.currencyToPrecision (code, amount, network);
+        request['amount'] = precisionAmount;
         const response = await this.sapiPostCapitalWithdrawApply (this.extend (request, params));
         //     { id: '9a67628b16ba4988ae20d329333f16bc' }
         return this.parseTransaction (response, currency);
@@ -8396,9 +8397,10 @@ export default class binance extends Exchange {
         }
         await this.loadMarkets ();
         const currency = this.currency (code);
+        const precisionAmount = this.currencyToPrecision (code, amount);
         const request = {
             'asset': currency['id'],
-            'amount': amount,
+            'amount': precisionAmount,
             'type': type,
         };
         const response = await this.sapiPostFuturesTransfer (this.extend (request, params));

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -605,7 +605,7 @@ export default class bitfinex2 extends Exchange {
                         'max': this.parseNumber (maxOrderSizeString),
                     },
                     'price': {
-                        'min': this.parseNumber ('1e-8'),
+                        'min': undefined,
                         'max': undefined,
                     },
                     'cost': {

--- a/ts/src/bitfinex2.ts
+++ b/ts/src/bitfinex2.ts
@@ -2640,10 +2640,11 @@ export default class bitfinex2 extends Exchange {
         }
         const wallet = this.safeString (params, 'wallet', 'exchange');  // 'exchange', 'margin', 'funding' and also old labels 'exchange', 'trading', 'deposit', respectively
         params = this.omit (params, 'network', 'wallet');
+        const precisionAmount = this.currencyToPrecision (code, amount, network);
         const request = {
             'method': networkId,
             'wallet': wallet,
-            'amount': this.numberToString (amount),
+            'amount': this.numberToString (precisionAmount),
             'address': address,
         };
         if (tag !== undefined) {

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2210,7 +2210,7 @@ export default class bitget extends Exchange {
         await this.loadMarkets ();
         const currency = this.currency (code);
         const networkId = this.networkCodeToId (chain, code);
-        const precisionAmount = this.currencyToPrecision (code, amount, networkId);
+        const precisionAmount = this.currencyToPrecision (code, amount, chain);
         const request = {
             'coin': currency['code'],
             'address': address,

--- a/ts/src/bitget.ts
+++ b/ts/src/bitget.ts
@@ -2210,11 +2210,12 @@ export default class bitget extends Exchange {
         await this.loadMarkets ();
         const currency = this.currency (code);
         const networkId = this.networkCodeToId (chain, code);
+        const precisionAmount = this.currencyToPrecision (code, amount, networkId);
         const request = {
             'coin': currency['code'],
             'address': address,
             'chain': networkId,
-            'amount': amount,
+            'amount': precisionAmount,
         };
         if (tag !== undefined) {
             request['tag'] = tag;
@@ -7210,10 +7211,11 @@ export default class bitget extends Exchange {
         const accountsByType = this.safeValue (this.options, 'accountsByType', {});
         const fromType = this.safeString (accountsByType, fromAccount);
         const toType = this.safeString (accountsByType, toAccount);
+        const precisionAmount = this.currencyToPrecision (code, amount);
         const request = {
             'fromType': fromType,
             'toType': toType,
-            'amount': amount,
+            'amount': precisionAmount,
             'coin': currency['code'],
         };
         const symbol = this.safeString (params, 'symbol');

--- a/ts/src/bitmart.ts
+++ b/ts/src/bitmart.ts
@@ -3358,9 +3358,10 @@ export default class bitmart extends Exchange {
         if (currencyId === undefined) {
             throw new NotSupported (this.id + ' fetchDepositAddress() does not support ' + code + ' with network ' + networkCode + ', specify a supported network in params.network');
         }
+        const precisionAmount = this.currencyToPrecision (code, amount, networkCode);
         const request = {
             'currency': currencyId,
-            'amount': amount,
+            'amount': precisionAmount,
             'destination': 'To Digital Address', // To Digital Address, To Binance, To OKEX
             'address': address,
         };

--- a/ts/src/bitstamp.ts
+++ b/ts/src/bitstamp.ts
@@ -2117,8 +2117,10 @@ export default class bitstamp extends Exchange {
         [ tag, params ] = this.handleWithdrawTagAndParams (tag, params);
         await this.loadMarkets ();
         this.checkAddress (address);
+        const network = this.safeString (params, 'network');
+        const precisionAmount = this.currencyToPrecision (code, amount, network);
         const request = {
-            'amount': amount,
+            'amount': precisionAmount,
         };
         let currency = undefined;
         let method = undefined;

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -5589,7 +5589,6 @@ export default class bybit extends Exchange {
         const currency = this.currency (code);
         const request = {
             'coin': currency['id'],
-            'amount': this.numberToString (amount),
             'address': address,
             'timestamp': this.nonce (),
             'feeType': 1, // bybit will deduce the fee from the amount
@@ -5599,6 +5598,8 @@ export default class bybit extends Exchange {
         }
         const [ networkCode, query ] = this.handleNetworkCodeAndParams (params);
         const networkId = this.networkCodeToId (networkCode);
+        const precisionAmount = this.currencyToPrecision (code, amount, networkId);
+        request['amount'] = this.numberToString (precisionAmount);
         if (networkId !== undefined) {
             request['chain'] = networkId.toUpperCase ();
         }

--- a/ts/src/bybit.ts
+++ b/ts/src/bybit.ts
@@ -5598,7 +5598,7 @@ export default class bybit extends Exchange {
         }
         const [ networkCode, query ] = this.handleNetworkCodeAndParams (params);
         const networkId = this.networkCodeToId (networkCode);
-        const precisionAmount = this.currencyToPrecision (code, amount, networkId);
+        const precisionAmount = this.currencyToPrecision (code, amount, networkCode);
         request['amount'] = this.numberToString (precisionAmount);
         if (networkId !== undefined) {
             request['chain'] = networkId.toUpperCase ();

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -3294,11 +3294,13 @@ export default class coinbase extends Exchange {
                 throw new ExchangeError (this.id + ' withdraw() could not find account id for ' + code);
             }
         }
+        const network = this.safeString (params, 'network');
+        const precisionAmount = this.currencyToPrecision (code, amount, network);
         const request = {
             'account_id': accountId,
             'type': 'send',
             'to': address,
-            'amount': amount,
+            'amount': precisionAmount,
             'currency': currency['id'],
         };
         if (tag !== undefined) {

--- a/ts/src/coinbase.ts
+++ b/ts/src/coinbase.ts
@@ -1318,6 +1318,9 @@ export default class coinbase extends Exchange {
             const id = this.safeString (currency, 'id', key);
             const name = this.safeString (currency, 'name');
             const code = this.safeCurrencyCode (id);
+            const lastCurrencyInformations = this.safeValue (this.currencies ?? {}, code, {});
+            // Precision is not provided by this endpoint but when we fetch balances - if we fetched it once, we use it since it won't change
+            const precision = this.safeValue (lastCurrencyInformations, 'precision', undefined);
             result[code] = {
                 'id': id,
                 'code': code,
@@ -1328,7 +1331,7 @@ export default class coinbase extends Exchange {
                 'deposit': undefined,
                 'withdraw': undefined,
                 'fee': undefined,
-                'precision': undefined,
+                'precision': precision,
                 'limits': {
                     'amount': {
                         'min': this.safeNumber (currency, 'min_size'),
@@ -1703,6 +1706,18 @@ export default class coinbase extends Exchange {
                         account['total'] = Precise.stringAdd (account['total'], total);
                     }
                     result[code] = account;
+                }
+            }
+            {
+                const currency = this.safeValue (balance, 'currency', {});
+                const currencyId = this.safeValue (currency, 'code');
+                const code = this.safeCurrencyCode (currencyId);
+                const exponent = this.safeInteger (currency, 'exponent');
+                const currencyInfo = this.safeValue (this.currencies, code);
+                if (currencyInfo && exponent) {
+                    // Exponent corresponds to DECIMAL precision mode, the exchande precision mode is TICK_SIZE so we convert it
+                    currencyInfo.precision = Math.pow (10, -exponent).toString ();
+                    this.currencies[code] = currencyInfo;
                 }
             }
         }

--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -3612,7 +3612,6 @@ export default class gate extends Exchange {
         const request = {
             'currency': currency['id'],
             'address': address,
-            'amount': this.currencyToPrecision (code, amount),
         };
         if (tag !== undefined) {
             request['memo'] = tag;
@@ -3626,6 +3625,8 @@ export default class gate extends Exchange {
         } else {
             request['chain'] = currency['id'];
         }
+        const precisionAmount = this.currencyToPrecision (code, amount, network);
+        request['amount'] = precisionAmount;
         const response = await this.privateWithdrawalsPostWithdrawals (this.extend (request, params));
         //
         //    {

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -5230,15 +5230,9 @@ export default class htx extends Exchange {
                 if (price === undefined) {
                     throw new InvalidOrder (this.id + ' createOrder() requires the price argument for market buy orders to calculate the total cost to spend (amount * price), alternatively set the createMarketBuyOrderRequiresPrice option or param to false and pass the cost to spend in the amount argument');
                 } else {
-                    // despite that cost = amount * price is in quote currency and should have quote precision
-                    // the exchange API requires the cost supplied in 'amount' to be of base precision
-                    // more about it here:
-                    // https://github.com/ccxt/ccxt/pull/4395
-                    // https://github.com/ccxt/ccxt/issues/7611
-                    // we use amountToPrecision here because the exchange requires cost in base precision
                     const amountString = this.numberToString (amount);
                     const priceString = this.numberToString (price);
-                    quoteAmount = this.amountToPrecision (symbol, Precise.stringMul (amountString, priceString));
+                    quoteAmount = this.priceToPrecision (symbol, Precise.stringMul (amountString, priceString));
                 }
             } else {
                 quoteAmount = this.amountToPrecision (symbol, amount);

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -5232,7 +5232,7 @@ export default class htx extends Exchange {
                 } else {
                     const amountString = this.numberToString (amount);
                     const priceString = this.numberToString (price);
-                    quoteAmount = this.priceToPrecision (symbol, Precise.stringMul (amountString, priceString));
+                    quoteAmount = this.costToPrecision (symbol, Precise.stringMul (amountString, priceString));
                 }
             } else {
                 quoteAmount = this.amountToPrecision (symbol, amount);

--- a/ts/src/htx.ts
+++ b/ts/src/htx.ts
@@ -6455,12 +6455,7 @@ export default class htx extends Exchange {
         if (ecid !== undefined) {
             request['chain'] = this.ecidToNetworkId (ecid, code);
         }
-        const networks = this.safeValue (currency, 'networks', {});
-        const networkItem = this.safeValue (networks, ecid, {});
-        let precision = this.safeValue (currency, 'precision');
-        precision = this.safeString (networkItem, 'precision', precision);
-        precision = this.precisionFromString (String (precision));
-        amount = parseFloat (this.decimalToPrecision (amount, TRUNCATE, precision));
+        amount = this.currencyToPrecision (code, amount, ecid);
         const withdrawOptions = this.safeValue (this.options, 'withdraw', {});
         if (this.safeBool (withdrawOptions, 'includeFee', false)) {
             let fee = this.safeNumber (params, 'fee');

--- a/ts/src/kraken.ts
+++ b/ts/src/kraken.ts
@@ -2686,9 +2686,10 @@ export default class kraken extends Exchange {
         if ('key' in params) {
             await this.loadMarkets ();
             const currency = this.currency (code);
+            const amountPrecision = this.currencyToPrecision (code, amount);
             const request = {
                 'asset': currency['id'],
-                'amount': amount,
+                'amount': amountPrecision,
             };
             if (address) {
                 request['address'] = address;

--- a/ts/src/kucoin.ts
+++ b/ts/src/kucoin.ts
@@ -4,7 +4,7 @@
 import Exchange from './abstract/kucoin.js';
 import { ExchangeError, ExchangeNotAvailable, InsufficientFunds, OrderNotFound, InvalidOrder, AccountSuspended, InvalidNonce, NotSupported, BadRequest, AuthenticationError, BadSymbol, RateLimitExceeded, PermissionDenied, InvalidAddress, ArgumentsRequired } from './base/errors.js';
 import { Precise } from './base/Precise.js';
-import { TICK_SIZE, TRUNCATE } from './base/functions/number.js';
+import { TICK_SIZE } from './base/functions/number.js';
 import { sha256 } from './static_dependencies/noble-hashes/sha256.js';
 import type { TransferEntry, Int, OrderSide, OrderType, Order, OHLCV, Trade, Balances, OrderRequest, Str, Transaction, Ticker, OrderBook, Tickers, Strings, Currency, Market } from './base/types.js';
 
@@ -2900,7 +2900,8 @@ export default class kucoin extends Exchange {
         await this.loadMarkets ();
         this.checkAddress (address);
         const currency = this.currency (code);
-        const truncatedAmount = this.decimalToPrecision (amount, TRUNCATE, 6);
+        const network = this.safeString (params, 'network');
+        const truncatedAmount = this.currencyToPrecision (code, amount, network);
         const request = {
             'currency': currency['id'],
             'address': address,

--- a/ts/src/mexc.ts
+++ b/ts/src/mexc.ts
@@ -5029,7 +5029,7 @@ export default class mexc extends Exchange {
         }
         const request = {
             'asset': currency['id'],
-            'amount': amount,
+            'amount': this.currencyToPrecision (code, amount),
             'fromAccountType': fromId,
             'toAccountType': toId,
         };
@@ -5050,7 +5050,7 @@ export default class mexc extends Exchange {
         //
         const transaction = this.parseTransfer (response, currency);
         return this.extend (transaction, {
-            'amount': amount,
+            'amount': this.amountToPrecision (code, amount),
             'fromAccount': fromAccount,
             'toAccount': toAccount,
         });
@@ -5152,10 +5152,11 @@ export default class mexc extends Exchange {
         this.checkAddress (address);
         await this.loadMarkets ();
         const currency = this.currency (code);
+        const precisionAmount = this.currencyToPrecision (code, amount, network);
         const request = {
             'coin': currency['id'],
             'address': address,
-            'amount': amount,
+            'amount': precisionAmount,
         };
         if (tag !== undefined) {
             request['memo'] = tag;

--- a/ts/src/okx.ts
+++ b/ts/src/okx.ts
@@ -4642,7 +4642,6 @@ export default class okx extends Exchange {
             'ccy': currency['id'],
             'toAddr': address,
             'dest': '4', // 2 = OKCoin International, 3 = OKX 4 = others
-            'amt': this.numberToString (amount),
         };
         let network = this.safeString (params, 'network'); // this line allows the user to specify either ERC20 or ETH
         if (network !== undefined) {
@@ -4651,6 +4650,8 @@ export default class okx extends Exchange {
             request['chain'] = currency['id'] + '-' + network;
             params = this.omit (params, 'network');
         }
+        const precisionAmount = this.currencyToPrecision (code, amount, network);
+        request['amt'] = this.numberToString (precisionAmount);
         let fee = this.safeString (params, 'fee');
         if (fee === undefined) {
             const currencies = await this.fetchCurrencies ();


### PR DESCRIPTION
These are the checks performed:
```
- CEDE_CEXS.BINANCE, -> OK
	- trade OK, withdraw FIXED, transfer SAFER
- CEDE_CEXS.COINBASE, -> No precision -> OK https://docs.cloud.coinbase.com/exchange/docs/types#numbers OR 16 for trades
	- trade OK, withdrawal FIXED, transfer NOT_FOUND
- CEDE_CEXS.KRAKEN, -> OK
	- trade OK, withdrawal FIXED, transfer OK
- CEDE_CEXS.GATEIO, -> OK
	- trade OK, withdrawal SAFER, transfer OK
- CEDE_CEXS.BITFINEX, -> OK
	- trade OK, withdrawal FIXED, transfer OK
- CEDE_CEXS.HTX, -> OK
	- trade OK, withdrawal SAFER, transfer OK
- CEDE_CEXS.KUCOIN, -> OK
	- trade OK, withdrawal FIXED but strange, transfer OK
- CEDE_CEXS.OKX, -> OK
	- trade OK, withdrawal FIXED, transfer OK
- CEDE_CEXS.BYBIT, -> OK
	- trade OK, withdrawal FIXED, transfer OK
- CEDE_CEXS.BITGET, -> no precision
	- trade OK, withdrawal FIXED, transfer FIXED
- CEDE_CEXS.BITSTAMP, -> OK
	- trade OK, withdrawal FIXED, transfer NOT_FOUND
- CEDE_CEXS.BITMART, -> OK
	- trade OK, withdrawal FIXED, transfer OK
- CEDE_CEXS.MEXC, -> OK
	- trade OK , withdrawal FIXED, transfer FIXED
```
Most of the fix consisted in truncating withdraw amounts.

Documentation for precision:
https://www.notion.so/cede-labs/CCXT-Internal-documentation-13e4c5acc36c4320be6649e476b8068b?pvs=4#72af583c39c44ce79515021d41b9fa16

-----------
What did I fix in `decimalToPrecision`
The bug was regarding exchanges with countingMode = TICK_SIZE and I deleted the code which is not related to this counting mode. As a parameter  countingMode = TICK_SIZE <=> numPrecisionDigits = "0.0001" or 0.0001 (example values) and it represents the smallest unit of variation.

```
const decimalToPrecision = (
    x,
    roundingMode,
    numPrecisionDigits,
    countingMode = DECIMAL_PLACES,
    paddingMode = NO_PADDING
) => {
    if (countingMode === TICK_SIZE) {
        if (typeof numPrecisionDigits === 'string') {
            // Here we parse "0.0001" to 0.0001 <-----------------------------------------------------------------------------------------------------------------
            numPrecisionDigits = parseFloat(numPrecisionDigits) 
        }
        ...
    }
    ...
    /*  handle tick size */
    if (countingMode === TICK_SIZE) {
         // Here we turn 0.0001 to 4 (precision expressed in  DECIMAL_PLACES <----------------------------------------------------------------
        const precisionDigitsString = decimalToPrecision (numPrecisionDigits, ROUND, 22, DECIMAL_PLACES, NO_PADDING);
        const newNumPrecisionDigits = precisionFromString (precisionDigitsString);
        // Here potentially correct rounding errors but it doesn't really matter to us <--------------------------------------------------------
        let missing = x % numPrecisionDigits;
        // See: https://github.com/ccxt/ccxt/pull/6486
        missing = Number (decimalToPrecision (missing, ROUND, 8, DECIMAL_PLACES, NO_PADDING));
        const fpError = decimalToPrecision (missing / numPrecisionDigits, ROUND, Math.max (newNumPrecisionDigits, 8), DECIMAL_PLACES, NO_PADDING);
        if (precisionFromString (fpError) !== 0) {
            if (roundingMode === ROUND) {
                if (x > 0) {
                    if (missing >= numPrecisionDigits / 2) {
                        x = x - missing + numPrecisionDigits;
                    } else {
                        x = x - missing;
                    }
                } else {
                    if (missing >= numPrecisionDigits / 2) {
                        x = Number (x) - missing;
                    } else {
                        x = Number (x) - missing - numPrecisionDigits;
                    }
                }
            } else if (roundingMode === TRUNCATE) {
                x = x - missing;
            }
        }
        // Once the precision is expressed in "DECIMAL_PLACES" we return decimalToPrecision <------------------------------------------
        return decimalToPrecision (x, ROUND, newNumPrecisionDigits, DECIMAL_PLACES, paddingMode);
    }
```

The issue is that `decimalToPrecision (x, ROUND, newNumPrecisionDigits, DECIMAL_PLACES, paddingMode);` is called with ROUND instead of TRUNCTATE.
So for this set of parameters:
`decimalToPrecision (0.04999, TRUNCATE, 0.001, TICK_SIZE, paddingMode);` it returns `0.05` instead of `0.049` because of the `ROUND`. 
The fix was just to replace `ROUND` with `roundingMode` so it makes it coherent.

--------------

To help you to test, this is the set I used... You might need to update some magic values depending on the exchange you are testing.

```
import { Exchange, htx, binance, bitfinex2, coinbase, gate, gateio, kraken,kucoin, okx, bybit, bitget } from "ccxt"

const exchangeList: Exchange[] = [
    new bitget({
        apiKey: "...",
        secret: "...",
    })
]

const TRUNCATE = 0;                // rounding mode
const ROUND = 1;
const ROUND_UP = 2;
const ROUND_DOWN = 3;
const DECIMAL_PLACES = 2;        // digits counting mode
const SIGNIFICANT_DIGITS = 3;
const TICK_SIZE = 4;
const NO_PADDING = 5;             // zero-padding mode
const PAD_WITH_ZERO = 6;
const precisionConstants = {
    ROUND,
    TRUNCATE,
    ROUND_UP,
    ROUND_DOWN,
    DECIMAL_PLACES,
    SIGNIFICANT_DIGITS,
    TICK_SIZE,
    NO_PADDING,
    PAD_WITH_ZERO,
};

const main = async () => {
    // Precision
    for (const ex of exchangeList) {
        await ex.loadMarkets()
        const currency: any = ex.currencies["ETH"]
        console.log("Exchange", Object.values(ex.currencies).map((c: any) => c.code).join(", "))

        console.log("Currency", currency?.code, "Precision", currency?.precision, "Object", currency)
        console.log("Networks", Object.values(currency.networks ?? {}).map((n: any) => n.network).join(", "))

        // Rounding tests
        const amounts = [
            0.,
            "0.",
            "0.0",
            "0.00",
            "0.054",
            0.0549,
            "0.0549",
            0.05499,
            "0.05499",
            0.054999,
            "0.054999",
            0.0549999,
            "0.0549999",
            0.05499999,
            "0.05499999",
            0.054999999,
            "0.054999999",
            0.0549999999,
            "0.0549999999",
            0.05499999994,
            "0.05499999999",
            0.054999999999,
            "0.054999998999",
            "0.054999999899",
            "0.054999999989",
            "0.054999999998",
            0.00000000000009,
            1.00000000000009,
            "0.00000000000000123"
        ]

        const networks = ex.safeDict(ex.options, 'networks', {});
        let network = "eth"
        network = ex.safeString(networks, network, network)
        console.log("Network", network)
        console.log("Precision", ex.precisionMode, ex.paddingMode)

        for (const amount of amounts) {
            console.log("Amount", amount, "currencyToPrecision\t", ex.currencyToPrecision("ETH", amount, network)) // SAME
            // Here replace the precision value
            console.log("Amount", amount, "decimalToPrecision\t", ex.decimalToPrecision(amount, 0, 0.0001, ex.precisionMode, ex.paddingMode));
            console.log("-------------------")
        }
    }
}
```

----

Check performed 
```
- TEST
- **Binance**
- Trade
- 0.00008 => 5.3412792 => priceToPrecision => 5.34
- Send
- 12.067699999999999 => 12.0677 (ok, rounding error note in doc)
- **Bitfinex**
- Trade
- (bug amount <0 => invalide price precision value)
- 1 -> 2.0797 2 5 3 5 => 2.0797 => 2.0797 OK
- 10.85470592 0 8 2 5 => 10.85470592 => 10.85470592 OK
- 8.828462956 0 8 2 5 => 8.828462955769400547 => 8.828462956 OK
- SEND
- parameters: 5.99999999 0 8 3 5 => 5.999999990000999 => 5.99999999 OK
- **HTX**
- TRADE
- parameters: 0.00015 0 0.000001 4 5 => 0.00015 => 0.00015 OK
- parameters: 10 0 1e-8 4 5 => 9.9999999999999419565 => 10 OK
- parameters: 0.0001603 0 0.000001 4 5 => 0.000160347548423938 => 0.0001603 OK
- parameters: 14.28141133 0 1e-8 4 5 => 14.2814113297820199998928 => 14.28141133 NOK (mais pouvons nous faire quelque chose? Impossible d'identifier l'erreur (ici ..1999.. au lieau de ..2)) "err-msg": "trade account balance is not enough, left: `14.281411329`"
- -> Idée: mitigiate avec precision +2 au lieu de precision +1 (100x moins de chances mais moins de tolérance à l'erreur)
- SEND
- OK
- **Coinbase**
- TRADE
- parameters: 0.1 0 0.01 4 5 => 0.1 => 0.1 OK
- parameters: 1.381 0 0.001 4 5 => 1.380999999999999997548 => 1.381 OK
- parameters: 16.0068 0 0.001 4 5 => 16.00681799999999999844 => 16.0068 OK
- parameters: 0.0002 0 1e-8 4 5 => 0.0001999999999999999999903 => 0.0002 OK
- parameters: 2.34 0 0.1 4 5 => 2.344918 => 2.34 and then after truncating 2.3 OK
- SEND
- 0.0000001001 -> Missing precision for coinbase (fixed)
- parameters: 0.0000001 0 1e-8 4 5 => 1.001e-7 => 0.0000001 OK
- **Bybit**
- Trade
- parameters: 1.2516 0 0.0001 4 5 => 1.2515999999999999995044 => 1.2516
- parameters: 0.000048 0 0.000001 4 5 => 0.000048 => 0.000048
  parameters: 0.0001068 0 0.000001 4 5 => 0.00010676564 => 0.0001068  
  Send  
- xx no funds
- Kucoin
- parameters: 0.1 0 0.0001 4 5 => 0.1 => 0.1 OK
  parameters: 12.7956 0 0.0001 4 5 => 12.7956 => 12.7956 OK  
  parameters: 0.10025 0 0.0001 4 5 => 0.100245674740484429 => 0.10025 => OK  
- SEND
- xx too expensive
- **Gate**
- Trade
- parameters: 8.6 0 0.01 4 5 => 8.6 => 8.6 OK
  parameters: 21.405 0 0.01 4 5 => 21.4046688 => 21.405 OK  
- parameters: 10 0 0.0001 4 5 => 9.9999999999999999988592 => 10 OK
- Send
- parameters: 0.532 0 0.0001 4 5 => 0.532000000999 => 0.532 OK
- **OKX**
- TRADE
- parameters: 1.1659 2 0.0001 4 5 => 1.1659 => 1.1659 OK
- parameters: 8.58001 0 0.0001 4 5 => 8.580008580008580008 => 8.58001 OK
- SEND
- xx not enough funds
- **Kraken**
- Skipped because incoming PR
- **Bitget**
- SEND/TRADE Not enough funds (fund s incoming)
```

Bug found 
Binance : Wrong usage of `decimalToPrecision` with the `ROUND` mode instead of the `TRUNCATE` mode
Bitfinex : Hardcoded precision leads to price estimation errors (ie: price = 0) and makes the min amount method fail
Coinbase : Currencies precisions were not fetched and could lead to approximation errors (ex: withdraw 1.0...8x...1, now it's fetched when calling getBalances and the currencies are truncated after x digits
HTX : Wrong usage of `priceToPrecision` (cf Binance)