### PR TITLE
fix gateio parse order to take into account if the buy order is parti…

### DIFF
--- a/ts/src/gate.ts
+++ b/ts/src/gate.ts
@@ -4514,10 +4514,12 @@ export default class gate extends Exchange {
             const averageString = this.safeString (order, 'avg_deal_price');
             average = this.parseNumber (averageString);
             if ((type === 'market') && (side === 'buy')) {
+                // filled_total represents the real traded quote token amount
+                const filledTotal = this.safeString2 (order, 'filled_total', 'amount');
                 remaining = Precise.stringDiv (remainingString, averageString);
                 price = undefined; // arrives as 0
-                cost = amount;
-                amount = Precise.stringDiv (amount, averageString);
+                cost = filledTotal;
+                amount = Precise.stringDiv (filledTotal, averageString);
             }
         }
         return this.safeOrder ({


### PR DESCRIPTION
Fixed parseOrder method for gate.io to retrieve the filled_total instead of the amount. 
I noticed that the amount doesn't represent the real traded quote amount in case of buy order (only the value provided by the taker when the order has been emitted). It could make some operation based on the result of the trade fail (it's the case for the trade&send feature). 

For example, a buy order DAI/USDT
<img width="247" alt="Screenshot 2024-03-11 at 16 51 46" src="https://github.com/cedelabs/ccxt/assets/60718973/19d1d0f5-83a1-4d94-a844-bcfa5449cfe7">
The amount is 12.0985 (in quote amount, value provided by the user)
The filled_total is 12.09758 (in quote amount, value really filled)
<img width="829" alt="Screenshot 2024-03-11 at 16 54 09" src="https://github.com/cedelabs/ccxt/assets/60718973/c7ec46f1-938e-4a58-80ab-2c67e544d3fe">

As you can see in the image which comes from gate.io UI, the filled_total represents the total traded value in quote currency

 
